### PR TITLE
DEV-6922: fix threading issue in LusidApiFactory

### DIFF
--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -168,7 +168,6 @@ namespace Lusid.Sdk.Tests
             Assert.That(errorResponse, Is.Null);
         }
 
-
         [TestCase(1, 10)]
         [TestCase(100, 25, Explicit = true)]
         public void Multi_Threaded_ApiFactory_Tasks(int quoteCount, int threadCount)
@@ -204,7 +203,5 @@ namespace Lusid.Sdk.Tests
 
             Task.WaitAll(tasks.ToArray());
         }
-
-
     }
 }

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
@@ -20,7 +20,11 @@ namespace Lusid.Sdk.Utilities
     /// <inheritdoc />
     public class LusidApiFactory : ILusidApiFactory
     {
-        private Dictionary<Type, IApiAccessor> _apis;
+        private static readonly IEnumerable<Type> ApiTypes = Assembly.GetAssembly(typeof(ApiClient))
+            .GetTypes()
+            .Where(t => typeof(IApiAccessor).IsAssignableFrom(t) && t.IsClass);
+
+        private readonly IReadOnlyDictionary<Type, IApiAccessor> _apis;
 
         /// <summary>
         /// Create a new factory using the specified configuration
@@ -49,7 +53,7 @@ namespace Lusid.Sdk.Utilities
             
             configuration.AddDefaultHeader("X-LUSID-Application", apiConfiguration.ApplicationName);
 
-            Init(configuration);
+            _apis = Init(configuration);
         }
 
         /// <summary>
@@ -59,17 +63,13 @@ namespace Lusid.Sdk.Utilities
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
-            Init(configuration);
+            _apis = Init(configuration);
         }
 
-        private void Init(Configuration configuration)
-        {   
-            IEnumerable<Type> apis = Assembly.GetAssembly(typeof(ApiClient))
-                .GetTypes()
-                .Where(t => typeof(IApiAccessor).IsAssignableFrom(t) && t.IsClass);
-
-            _apis = new Dictionary<Type, IApiAccessor>();
-            foreach (var api in apis)
+        private static Dictionary<Type, IApiAccessor> Init(Configuration configuration)
+        {
+            var dict = new Dictionary<Type, IApiAccessor>();
+            foreach (Type api in ApiTypes)
             {
                 if (!(Activator.CreateInstance(api, configuration) is IApiAccessor impl))
                 {
@@ -79,9 +79,11 @@ namespace Lusid.Sdk.Utilities
                 var @interface = api.GetInterfaces()
                     .First(i => typeof(IApiAccessor).IsAssignableFrom(i));
 
-                _apis[api] = impl;
-                _apis[@interface] = impl;
+                dict[api] = impl;
+                dict[@interface] = impl;
             }
+
+            return dict;
         }
 
         /// <inheritdoc />
@@ -93,6 +95,7 @@ namespace Lusid.Sdk.Utilities
             {
                 throw new InvalidOperationException($"Unable to find api: {typeof(TApi)}");
             }
+
             return api as TApi;
         }
     }

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactoryBuilder.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactoryBuilder.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Threading;
-
 namespace Lusid.Sdk.Utilities
 {
     /// <summary>
@@ -8,9 +5,6 @@ namespace Lusid.Sdk.Utilities
     /// </summary>
     public static class LusidApiFactoryBuilder
     {
-        private static readonly Dictionary<int, ILusidApiFactory> ThreadFactories = new Dictionary<int, ILusidApiFactory>();
-        private static readonly object Lock = new object();
-
         /// <summary>
         /// Create an ILusidApiFactory using the specified configuration file.  For details on the format of the configuration file see https://support.lusid.com/getting-started-with-apis-sdks
         /// </summary>
@@ -20,31 +14,20 @@ namespace Lusid.Sdk.Utilities
             return new LusidApiFactory(apiConfig);
         }
 
-
         /// <summary>
         /// Create an ILusidApiFactory using the specified Url and Token Provider
         /// </summary>
         public static ILusidApiFactory Build(string url, ITokenProvider tokenProvider)
         {
-            lock (Lock)
+            // TokenProviderConfiguration.ApiClient is the client used by LusidApiFactory and is 
+            // NOT thread-safe, so there needs to be a separate instance for each instance of LusidApiFactory.
+            // Do NOT cache the LusidApiFactory instances (DEV-6922)
+            var config = new TokenProviderConfiguration(tokenProvider)
             {
-                var threadId = Thread.CurrentThread.ManagedThreadId;
+                BasePath = url
+            };
 
-                if (!ThreadFactories.TryGetValue(threadId, out var factory))
-                {
-                    // TokenProviderConfiguration.ApiClient is the client used by LusidApiFactory and is 
-                    // not threadsafe, so there needs to be a separate instance for each instance of LusidApiFactory
-                    var config = new TokenProviderConfiguration(tokenProvider)
-                    {
-                        BasePath = url
-                    };
-
-                    factory = new LusidApiFactory(config);
-                    ThreadFactories[threadId] = factory;
-                }
-
-                return factory;
-            }
+            return new LusidApiFactory(config);
         }
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](https://github.com/finbourne/lusid-sdk-python-preview/blob/master/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Fixes threading issue in `LusidApiFactory` when used in an async context. The previous code assumed `ManagedThreadId` would be constant during an individual (single-threaded) request, but this is not the case if an async continuation (e.g. following an `await`) is employed in the calling application
