### PR TITLE
DEV-7152: add finaliser to ApiClient to avoid socket leak due to .NET…

### DIFF
--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -204,7 +204,7 @@ namespace Lusid.Sdk.Tests
             Task.WaitAll(tasks.ToArray());
         }
 
-        [Test, Explicit("Only an issue on .NET Core 2.2 on Linux OS")]
+        [Test, Explicit("Only an issue on .NET Core 2.2 on Linux / MacOS")]
         public void LinuxSocketLeakTest() // See DEV-7152
         {
             ApiConfiguration config = ApiConfigurationBuilder.Build("secrets.json");
@@ -219,6 +219,16 @@ namespace Lusid.Sdk.Tests
                 api = BuildApi();
                 PortfolioGroup result = api.GetPortfolioGroup("sdktest", "TestGroup");
                 Assert.That(result, Is.Not.Null);
+
+                // Option 1: force dispose of ApiClient
+                //api.Configuration.ApiClient.Dispose();
+
+                // Option 2: force all finalizers to run
+                if (i % 100 == 0)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                }
             }
 
             /*** Local Functions ***/

--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -203,5 +203,33 @@ namespace Lusid.Sdk.Tests
 
             Task.WaitAll(tasks.ToArray());
         }
+
+        [Test, Explicit("Only an issue on .NET Core 2.2 on Linux OS")]
+        public void LinuxSocketLeakTest() // See DEV-7152
+        {
+            ApiConfiguration config = ApiConfigurationBuilder.Build("secrets.json");
+            var provider = new ClientCredentialsFlowTokenProvider(config);
+
+            var api = BuildApi();
+            api.CreatePortfolioGroup("sdktest", new CreatePortfolioGroupRequest("TestGroup", displayName: "TestGroup"));
+
+            // This loop should eventually throw a SocketException: "Address already in use" once all the sockets have been exhausted
+            for (int i = 0; i < 50_000; i++)
+            {
+                api = BuildApi();
+                PortfolioGroup result = api.GetPortfolioGroup("sdktest", "TestGroup");
+                Assert.That(result, Is.Not.Null);
+            }
+
+            /*** Local Functions ***/
+            IPortfolioGroupsApi BuildApi()
+            {
+                // An instance of HttpClient is created within LusidApiFactory.Configuration.ApiClient.RestClient
+                // which wasn't being disposed
+                ILusidApiFactory factory = LusidApiFactoryBuilder.Build(config.ApiUrl, provider);
+                IPortfolioGroupsApi api = factory.Api<IPortfolioGroupsApi>();
+                return api;
+            }
+        }
     }
 }

--- a/sdk/Lusid.Sdk/Client/ApiClient.Dispose.cs
+++ b/sdk/Lusid.Sdk/Client/ApiClient.Dispose.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Lusid.Sdk.Client
+{
+    // DEV-7152: Bug in .NET Core 2.2 means any un-disposed HttpClients will leak sockets
+    // https://github.com/dotnet/corefx/pull/38499
+    // https://github.com/dotnet/runtime/issues/29327
+    // Use a finalizer to ensure RestClient (and thus HttpClient) instances are always disposed
+
+    public partial class ApiClient : IDisposable
+    {
+        /// <summary />
+        public void Dispose()
+        {
+            DisposeImpl();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary />
+        ~ApiClient()
+        {
+            DisposeImpl();
+        }
+
+        private void DisposeImpl()
+        {
+            RestClient?.Dispose();
+        }
+    }
+}

--- a/sdk/Lusid.Sdk/Utilities/ApiClient.Dispose.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiClient.Dispose.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+// ReSharper disable once CheckNamespace
 namespace Lusid.Sdk.Client
 {
     // DEV-7152: Bug in .NET Core 2.2 means any un-disposed HttpClients will leak sockets


### PR DESCRIPTION
Due to a bug in .NET Core 2.2, any HttpClient instances which are not explicitly disposed will leak sockets when running on Linux.

This change ensures the `HttpClient` instances held by `RestClient` instances are always disposed, through use of a finalizer.