### PR TITLE
DEV-7485: updated to handle new orders api

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Orders.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Orders.cs
@@ -65,7 +65,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                             { $"Order/{testScope}/Strategy", new PerpetualProperty($"Order/{testScope}/Strategy", new PropertyValue("RiskArb")) },
                         },
                         side: "Buy",
-                        orderBook: new ResourceId(testScope, "OrdersTestBook")
+                        orderBookId: new ResourceId(testScope, "OrdersTestBook")
                     )
                 });
 
@@ -114,7 +114,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                             { $"Order/{testScope}/Strategy", new PerpetualProperty($"Order/{testScope}/Strategy", new PropertyValue("RiskArb")) },
                         },
                         side: "Buy",
-                        orderBook: new ResourceId(testScope, "OrdersTestBook")
+                        orderBookId: new ResourceId(testScope, "OrdersTestBook")
                     )
                 });
 
@@ -156,7 +156,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         portfolioId: new ResourceId(testScope, "OrdersTestPortfolio"),
                         properties: new Dictionary<string, PerpetualProperty>(),
                         side: "Buy",
-                        orderBook: new ResourceId(testScope, "OrdersTestBook")
+                        orderBookId: new ResourceId(testScope, "OrdersTestBook")
                     )
                 });
 
@@ -197,7 +197,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                             { $"Order/{testScope}/Strategy", new PerpetualProperty($"Order/{testScope}/Strategy", new PropertyValue("RiskArb")) },
                         },
                         side: "Buy",
-                        orderBook: new ResourceId(testScope, "OrdersTestBook")
+                        orderBookId: new ResourceId(testScope, "OrdersTestBook")
                         )
                 });
             
@@ -251,7 +251,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                             { $"Order/{testScope}/Strategy", new PerpetualProperty($"Order/{testScope}/Strategy", new PropertyValue("RiskArb")) },
                         },
                         side: "Buy",
-                        orderBook: new ResourceId(testScope, "OrdersTestBook")
+                        orderBookId: new ResourceId(testScope, "OrdersTestBook")
                     ),
                     new OrderRequest(
                         id: orderId2,
@@ -276,7 +276,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                             { $"Order/{testScope}/Strategy", new PerpetualProperty($"Order/{testScope}/Strategy", new PropertyValue("UK Growth")) },
                         },
                         side: "Sell",
-                        orderBook: new ResourceId(testScope, "AnotherOrdersTestBook")
+                        orderBookId: new ResourceId(testScope, "AnotherOrdersTestBook")
                     ),
                     new OrderRequest(
                         id: orderId3,
@@ -301,7 +301,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                             { $"Order/{testScope}/Strategy", new PerpetualProperty($"Order/{testScope}/Strategy", new PropertyValue("RiskArb")) },
                         },
                         side: "Buy",
-                        orderBook: new ResourceId(testScope, "OrdersTestBook")
+                        orderBookId: new ResourceId(testScope, "OrdersTestBook")
                     )
                 });
 
@@ -338,7 +338,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
             var orderBookFilter = _ordersApi.ListOrders(asAt: t, filter: $"OrderBook eq '{testScope}/AnotherOrdersTestBook'");
 
             Assert.That(orderBookFilter.Values.Count, Is.EqualTo(1));
-            Assert.That(orderBookFilter.Values.All(rl => rl.OrderBook.Code.Equals("AnotherOrdersTestBook")));
+            Assert.That(orderBookFilter.Values.All(rl => rl.OrderBookId.Code.Equals("AnotherOrdersTestBook")));
         }
     }
 }

--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Orders.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Orders.cs
@@ -34,15 +34,16 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
         public void Upsert_Simple_Order()
         {
             var testScope = $"TestScope-{Guid.NewGuid().ToString()}";
-            var orderId = $"Order-{Guid.NewGuid().ToString()}";
-            
+            var order = $"Order-{Guid.NewGuid().ToString()}";
+            var orderId = new ResourceId(testScope, order);
+
             // We want to make a request for a single order. The internal security id will be mapped on upsert
             // from the instrument identifiers passed.
             var request = new OrderSetRequest(
                 orderRequests: new List<OrderRequest>
                 {
                     new OrderRequest(
-                        code: orderId,
+                        id: orderId,
                         quantity: 100,
                         // These instrument identifiers should all map to the same instrument. If the instance of
                         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -54,7 +55,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         },
                         // [Experimental] Currently this portfolio doesn't need to exist. As the domain model evolves
                         // this reference might disappear, or might become a strict reference to an existing portfolio.
-                        portfolio: new ResourceId(testScope, "OrdersTestPortfolio"),
+                        portfolioId: new ResourceId(testScope, "OrdersTestPortfolio"),
                         properties: new Dictionary<string, PerpetualProperty>
                         {
                             { $"Order/{testScope}/TIF", new PerpetualProperty($"Order/{testScope}/TIF", new PropertyValue("GTC")) },
@@ -69,7 +70,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                 });
 
             // We can ask the Orders API to upsert this order for us
-            var upsertResult = _ordersApi.UpsertOrders(scope: testScope, request: request);
+            var upsertResult = _ordersApi.UpsertOrders(request: request);
 
             // The return gives us a list of orders upserted, and LusidInstrument for each has been mapped to a LUID
             // using the instrument identifiers passed
@@ -82,15 +83,16 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
         public void Upsert_Simple_Order_With_Unknown_Instrument()
         {
             var testScope = $"TestScope-{Guid.NewGuid().ToString()}";
-            var orderId = $"Order-{Guid.NewGuid().ToString()}";
-            
+            var order = $"Order-{Guid.NewGuid().ToString()}";
+            var orderId = new ResourceId(testScope, order);
+
             // We want to make a request for a single order. We'll map the internal security id to an Unknown placeholder
             // if we can't translate it.
             var initialRequest = new OrderSetRequest(
                 orderRequests: new List<OrderRequest>
                 {
                     new OrderRequest(
-                        code: orderId,
+                        id: orderId,
                         quantity: 100,
                         // These instrument identifiers should all map to the same instrument. If the instance of
                         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -102,7 +104,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         },
                         // [Experimental] Currently this portfolio doesn't need to exist. As the domain model evolves
                         // this reference might disappear, or might become a strict reference to an existing portfolio
-                        portfolio: new ResourceId(testScope, "OrdersTestPortfolio"),
+                        portfolioId: new ResourceId(testScope, "OrdersTestPortfolio"),
                         properties: new Dictionary<string, PerpetualProperty>
                         {
                             { $"Order/{testScope}/TIF", new PerpetualProperty($"Order/{testScope}/TIF", new PropertyValue("GTC")) },
@@ -117,7 +119,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                 });
 
             // We can ask the Orders API to upsert this order for us
-            var upsertResult = _ordersApi.UpsertOrders(scope: testScope, request: initialRequest);
+            var upsertResult = _ordersApi.UpsertOrders(request: initialRequest);
 
             // The return gives us a list of orders upserted, and LusidInstrument for each has been mapped to a LUID
             // using the instrument identifiers passed
@@ -130,15 +132,16 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
         public void Update_Simple_Order()
         {
             var testScope = $"TestScope-{Guid.NewGuid().ToString()}";
-            var orderId = $"Order-{Guid.NewGuid().ToString()}";
-            
+            var order = $"Order-{Guid.NewGuid().ToString()}";
+            var orderId = new ResourceId(testScope, order);
+
             // We want to make a request for a single order. The internal security id will be mapped on upsert
             // from the instrument identifiers passed. Properties
             var request = new OrderSetRequest(
                 orderRequests: new List<OrderRequest>
                 {
                     new OrderRequest(
-                        code: orderId,
+                        id: orderId,
                         quantity: 100,
                         // These instrument identifiers should all map to the same instrument. If the instance of
                         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -150,14 +153,14 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         },
                         // [Experimental] Currently this portfolio doesn't need to exist. As the domain model evolves
                         // this reference might disappear, or might become a strict reference to an existing portfolio
-                        portfolio: new ResourceId(testScope, "OrdersTestPortfolio"),
+                        portfolioId: new ResourceId(testScope, "OrdersTestPortfolio"),
                         properties: new Dictionary<string, PerpetualProperty>(),
                         side: "Buy",
                         orderBook: new ResourceId(testScope, "OrdersTestBook")
                     )
                 });
 
-            var upsertResult = _ordersApi.UpsertOrders(scope: testScope, request: request);
+            var upsertResult = _ordersApi.UpsertOrders(request: request);
 
             // The return gives us a list of orders upserted, and LusidInstrument for each has been mapped to a LUID
             // using the instrument identifiers passed
@@ -172,7 +175,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                 orderRequests: new List<OrderRequest>
                 {
                     new OrderRequest(
-                        code: orderId,
+                        id: orderId,
                         quantity: 500,
                         // These instrument identifiers should all map to the same instrument. If the instance of
                         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -184,7 +187,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         },
                         // [Experimental] Currently this portfolio doesn't need to exist. As the domain model evolves
                         // this reference might disappear, or might become a strict reference to an existing portfolio
-                        portfolio: new ResourceId(testScope, "OrdersTestPortfolio"),
+                        portfolioId: new ResourceId(testScope, "OrdersTestPortfolio"),
                         properties: new Dictionary<string, PerpetualProperty>
                         {
                             { $"Order/{testScope}/TIF", new PerpetualProperty($"Order/{testScope}/TIF", new PropertyValue("GTC")) },
@@ -198,7 +201,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         )
                 });
             
-            upsertResult = _ordersApi.UpsertOrders(scope: testScope, request: updateRequest);
+            upsertResult = _ordersApi.UpsertOrders(request: updateRequest);
             
             // The return gives us a list of orders upserted, and LusidInstrument for each has been mapped to a LUID
             // using the instrument identifiers passed. We can see that the quantity has been udpated, and properties added
@@ -213,9 +216,12 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
         public void Upsert_And_Retrieve_Simple_Orders()
         {
             var testScope = $"TestScope-{Guid.NewGuid().ToString()}";
-            var orderId1 = $"Order-{Guid.NewGuid().ToString()}";
-            var orderId2 = $"Order-{Guid.NewGuid().ToString()}";
-            var orderId3 = $"Order-{Guid.NewGuid().ToString()}";
+            var order1 = $"Order-{Guid.NewGuid().ToString()}";
+            var order2 = $"Order-{Guid.NewGuid().ToString()}";
+            var order3 = $"Order-{Guid.NewGuid().ToString()}";
+            var orderId1 = new ResourceId(testScope, order1);
+            var orderId2 = new ResourceId(testScope, order2);
+            var orderId3 = new ResourceId(testScope, order3);
             
             // We want to make a request for a single order. The internal security id will be mapped on upsert
             // from the instrument identifiers passed. We can filter on a number of parameters on query.
@@ -223,7 +229,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                 orderRequests: new List<OrderRequest>
                 {
                     new OrderRequest(
-                        code: orderId1,
+                        id: orderId1,
                         quantity: 100,
                         // These instrument identifiers should all map to the same instrument. If the instance of
                         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -235,7 +241,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         },
                         // [Experimental] Currently this portfolio doesn't need to exist. As the domain model evolves
                         // this reference might disappear, or might become a strict reference to an existing portfolio
-                        portfolio: new ResourceId(testScope, "OrdersTestPortfolio"),
+                        portfolioId: new ResourceId(testScope, "OrdersTestPortfolio"),
                         properties: new Dictionary<string, PerpetualProperty>
                         {
                             { $"Order/{testScope}/TIF", new PerpetualProperty($"Order/{testScope}/TIF", new PropertyValue("GTC")) },
@@ -248,7 +254,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         orderBook: new ResourceId(testScope, "OrdersTestBook")
                     ),
                     new OrderRequest(
-                        code: orderId2,
+                        id: orderId2,
                         quantity: 200,
                         // These instrument identifiers should all map to the same instrument. If the instance of
                         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -260,7 +266,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         },
                         // [Experimental] Currently this portfolio doesn't need to exist. As the domain model evolves
                         // this reference might disappear, or might become a strict reference to an existing portfolio
-                        portfolio: new ResourceId(testScope, "OrdersTestPortfolio"),
+                        portfolioId: new ResourceId(testScope, "OrdersTestPortfolio"),
                         properties: new Dictionary<string, PerpetualProperty>
                         {
                             { $"Order/{testScope}/TIF", new PerpetualProperty($"Order/{testScope}/TIF", new PropertyValue("GTC")) },
@@ -273,7 +279,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         orderBook: new ResourceId(testScope, "AnotherOrdersTestBook")
                     ),
                     new OrderRequest(
-                        code: orderId3,
+                        id: orderId3,
                         quantity: 300,
                         // These instrument identifiers should all map to the same instrument. If the instance of
                         // LUSID has the specified instruments registered these identifiers will get resolved to
@@ -285,7 +291,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                         },
                         // [Experimental] Currently this portfolio doesn't need to exist. As the domain model evolves
                         // this reference might disappear, or might become a strict reference to an existing portfolio
-                        portfolio: new ResourceId(testScope, "OrdersTestPortfolio"),
+                        portfolioId: new ResourceId(testScope, "OrdersTestPortfolio"),
                         properties: new Dictionary<string, PerpetualProperty>
                         {
                             { $"Order/{testScope}/TIF", new PerpetualProperty($"Order/{testScope}/TIF", new PropertyValue("GTC")) },
@@ -300,7 +306,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                 });
 
             // We can ask the Orders API to upsert this order for us
-            var upsertResult = _ordersApi.UpsertOrders(scope: testScope, request: request);
+            var upsertResult = _ordersApi.UpsertOrders(request: request);
 
             // The return gives us a list of orders upserted, and LusidInstrument for each has been mapped to a LUID
             // using the instrument identifiers passed
@@ -309,27 +315,27 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
 
             var t = upsertResult.Values.First().Version.AsAtDate;
 
-            var quantityFilter = _ordersApi.ListOrders(scope: testScope, asAt: t, filter: "Quantity gt 100");
+            var quantityFilter = _ordersApi.ListOrders(asAt: t, filter: "Quantity gt 100");
 
             Assert.That(quantityFilter.Values.Count, Is.EqualTo(2));
             Assert.That(quantityFilter.Values.All(rl => rl.Quantity > 100));
 
-            var propertyFilter = _ordersApi.ListOrders(scope: testScope, asAt: t, filter: $"Properties[{testScope}/OrderGroup] eq 'UK Test Orders 2'");
+            var propertyFilter = _ordersApi.ListOrders(asAt: t, filter: $"Properties[{testScope}/OrderGroup] eq 'UK Test Orders 2'");
 
             Assert.That(propertyFilter.Values.Count, Is.EqualTo(1));
             Assert.That(propertyFilter.Values.Single(rl => rl.Id.Code.Equals(orderId3)).Properties[$"Order/{testScope}/OrderGroup"].Value.LabelValue, Is.EqualTo("UK Test Orders 2"));
             
-            var instrumentFilter = _ordersApi.ListOrders(scope: testScope, asAt: t, filter: $"LusidInstrumentId eq '{_instrumentIds.First()}'");
+            var instrumentFilter = _ordersApi.ListOrders(asAt: t, filter: $"LusidInstrumentId eq '{_instrumentIds.First()}'");
             
             Assert.That(instrumentFilter.Values.Count, Is.EqualTo(2));
             Assert.That(instrumentFilter.Values.All(rl => rl.LusidInstrumentId.Equals(_instrumentIds[0])));
 
-            var sideFilter = _ordersApi.ListOrders(scope: testScope, asAt: t, filter: $"Side eq 'Sell'");
+            var sideFilter = _ordersApi.ListOrders(asAt: t, filter: $"Side eq 'Sell'");
 
             Assert.That(sideFilter.Values.Count, Is.EqualTo(1));
             Assert.That(sideFilter.Values.All(rl => rl.Side.Equals("Sell")));
 
-            var orderBookFilter = _ordersApi.ListOrders(scope: testScope, asAt: t, filter: $"OrderBook eq '{testScope}/AnotherOrdersTestBook'");
+            var orderBookFilter = _ordersApi.ListOrders(asAt: t, filter: $"OrderBook eq '{testScope}/AnotherOrdersTestBook'");
 
             Assert.That(orderBookFilter.Values.Count, Is.EqualTo(1));
             Assert.That(orderBookFilter.Values.All(rl => rl.OrderBook.Code.Equals("AnotherOrdersTestBook")));


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

- Remove `Scope` from `Order`s routes.
- Order Id now a `ResourceId`
- Use `OrderId` `Scope` to determine scope of order.
- Enable filter on scope for orders and allocations.
- Ensure we write out `OrderId` as a safe string (no client) in logs.
- Corrects likely `UserId` > `Client.Name` problem in `SetEventHeader`.
- Re-organised some Orders tests.
