### PR TITLE
DEV-8462: Support multi-value properties

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
@@ -210,14 +210,14 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
                             propertyValue)
                 }
             );
-            Assert.That(propertiesUpsertResult.Properties.Values.Single().Value.LabelValueSet, Is.EqualTo(propertyValue.LabelValueSet));
+            Assert.That(propertiesUpsertResult.Properties.Values.Single().Value.LabelValueSet, Is.EqualTo(propertyValue.LabelValueSet).Using(LabelValueSetEquality));
 
             var portfolioProperties = _apiFactory.Api<IPortfoliosApi>().GetPortfolioProperties(TestDataUtilities.TutorialScope, portfolioResult.Id.Code).Properties;
 
             Assert.That(portfolioProperties.Keys, Is.EquivalentTo(new [] { propertyDefinitionResult.Key}));
 
             var returnedProperty = portfolioProperties[propertyDefinitionResult.Key];
-            Assert.That(returnedProperty.Value, Is.EqualTo(propertyValue).Using(Comparer));
+            Assert.That(returnedProperty.Value, Is.EqualTo(propertyValue).Using(PropertyEquality));
         }
     }
 }

--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
@@ -217,7 +217,7 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
             Assert.That(portfolioProperties.Keys, Is.EquivalentTo(new [] { propertyDefinitionResult.Key}));
 
             var returnedProperty = portfolioProperties[propertyDefinitionResult.Key];
-            Assert.That(returnedProperty.Value, Is.EqualTo(propertyValue).Using(PropertyEquality));
+            Assert.That(returnedProperty.Value, Is.EqualTo(propertyValue).Using(PropertyValueEquality));
         }
     }
 }

--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
@@ -155,7 +155,7 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
         public void Create_Portfolio_With_MultiValue_Property()
         {
             var uuid = Guid.NewGuid().ToString();
-            var propertyName = $"manager-{uuid}";
+            var propertyName = $"managers-{uuid}";
             var effectiveDate = new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero);
             
             //    Details of the property to be created
@@ -176,7 +176,7 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
                 
                 code: propertyName,
                 valueRequired: false,
-                displayName: "Manager",
+                displayName: "Managers",
                 dataTypeId: new ResourceId("system", "string")
             );
             
@@ -184,7 +184,7 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
             var propertyDefinitionResult = _apiFactory.Api<IPropertyDefinitionsApi>().CreatePropertyDefinition(multiValuePropertyDefinition);
             
             //    Create the property values
-            var propertyValue = CreateLabelSet("a","b");
+            var propertyValue = CreateLabelSet("PortfolioManager1","PortfolioManager2");
             
             //    Details of the new portfolio to be created, created here with the minimum set of mandatory fields 
             var createPortfolioRequest = new CreateTransactionPortfolioRequest(

--- a/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
+++ b/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Lusid.Sdk.Model;
+
+namespace Lusid.Sdk.Utilities
+{
+    /// <summary>
+    /// Utilities for working with Properties.
+    /// </summary>
+    internal static class PropertyExtensions
+    {
+        /// <summary>
+        /// Creates a PropertyValue containing a string label.
+        /// </summary>
+        public static PropertyValue CreateLabel(string value)
+        {
+            return new PropertyValue(labelValue: value);
+        }
+
+        /// <summary>
+        /// Creates a PropertyValue containing a metric value with unit.
+        /// </summary>
+        public static PropertyValue CreateMetric(decimal value, string unit)
+        {
+            return new PropertyValue(metricValue: new MetricValue(value, unit));
+        }
+        
+        /// <summary>
+        /// Creates a PropertyValue containing a set of distinct string labels.
+        /// </summary>
+        public static PropertyValue CreateLabelSet(params string[] values)
+        {
+            return new PropertyValue(labelValueSet: new LabelValueSet(values.ToList()));
+        }
+        
+        public static PropertyComparer Comparer => new PropertyComparer(); 
+
+        /// <summary>
+        /// Compares LabelSetValues without ordering, unlike the default SDK behaviour.
+        /// </summary>
+        public class PropertyComparer : IComparer<Property>
+        {
+            public int Compare(Property p1, Property p2)
+            {
+                return Equals(p1, p2, CompareNonNull) ? 0 : 1;
+            }
+            
+            private bool CompareNonNull(Property p1, Property p2)
+            {
+                return Equals(p1.Key, p2.Key) &&
+                       Equals(p1.Value.LabelValue, p2.Value.LabelValue) &&
+                       Equals(p1.Value.MetricValue, p2.Value.MetricValue) &&
+                       Equals(p1.Value.LabelValueSet, p2.Value.LabelValueSet,
+                           (a,b) => a.Values.OrderBy(e => e).SequenceEqual(b.Values.OrderBy(e => e)));
+            }
+            
+            private bool Equals<T>(T a, T b, Func<T,T,bool> nonNullEquals)
+            {
+                if (ReferenceEquals(a, null) && ReferenceEquals(b, null))
+                    return true;
+                
+                if (ReferenceEquals(a, null) || ReferenceEquals(b, null))
+                    return false;
+
+                return nonNullEquals(a, b);
+            }
+        }
+    }
+}

--- a/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
+++ b/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
@@ -31,6 +31,11 @@ namespace Lusid.Sdk.Utilities
         /// </summary>
         public static PropertyValue CreateLabelSet(params string[] values)
         {
+            if (values.Distinct().Count() != values.Length)
+            {
+                throw new ArgumentException("Labels must be distinct.", nameof(values));
+            }
+            
             return new PropertyValue(labelValueSet: new LabelValueSet(values.ToList()));
         }
         

--- a/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
+++ b/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
@@ -39,25 +39,24 @@ namespace Lusid.Sdk.Utilities
             return new PropertyValue(labelValueSet: new LabelValueSet(values.ToList()));
         }
         
-        public static PropertyComparer PropertyEquality => new PropertyComparer();
+        public static PropertyValueComparer PropertyValueEquality => new PropertyValueComparer();
         public static LabelValueSetComparer LabelValueSetEquality => new LabelValueSetComparer();
 
         /// <summary>
         /// Compares LabelSetValues without ordering, unlike the default SDK behaviour.
         /// </summary>
-        public class PropertyComparer : IComparer<Property>
+        public class PropertyValueComparer : IComparer<PropertyValue>
         {
-            public int Compare(Property p1, Property p2)
+            public int Compare(PropertyValue pv1, PropertyValue pv2)
             {
-                return AreEqual(p1, p2, CompareNonNull) ? 0 : 1;
+                return AreEqual(pv1, pv2, CompareNonNull) ? 0 : 1;
             }
             
-            private static bool CompareNonNull(Property p1, Property p2)
+            private static bool CompareNonNull(PropertyValue pv1, PropertyValue pv2)
             {
-                return Equals(p1.Key, p2.Key) &&
-                       Equals(p1.Value.LabelValue, p2.Value.LabelValue) &&
-                       Equals(p1.Value.MetricValue, p2.Value.MetricValue) &&
-                       AreEqual(p1.Value.LabelValueSet, p2.Value.LabelValueSet, LabelValueSetComparer.CompareNonNull);
+                return Equals(pv1.LabelValue, pv2.LabelValue) &&
+                       Equals(pv1.MetricValue, pv2.MetricValue) &&
+                       AreEqual(pv1.LabelValueSet, pv2.LabelValueSet, LabelValueSetComparer.CompareNonNull);
             }
         }
 

--- a/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
+++ b/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
@@ -39,7 +39,8 @@ namespace Lusid.Sdk.Utilities
             return new PropertyValue(labelValueSet: new LabelValueSet(values.ToList()));
         }
         
-        public static PropertyComparer Comparer => new PropertyComparer(); 
+        public static PropertyComparer PropertyEquality => new PropertyComparer();
+        public static LabelValueSetComparer LabelValueSetEquality => new LabelValueSetComparer();
 
         /// <summary>
         /// Compares LabelSetValues without ordering, unlike the default SDK behaviour.
@@ -48,28 +49,41 @@ namespace Lusid.Sdk.Utilities
         {
             public int Compare(Property p1, Property p2)
             {
-                return Equals(p1, p2, CompareNonNull) ? 0 : 1;
+                return AreEqual(p1, p2, CompareNonNull) ? 0 : 1;
             }
             
-            private bool CompareNonNull(Property p1, Property p2)
+            private static bool CompareNonNull(Property p1, Property p2)
             {
                 return Equals(p1.Key, p2.Key) &&
                        Equals(p1.Value.LabelValue, p2.Value.LabelValue) &&
                        Equals(p1.Value.MetricValue, p2.Value.MetricValue) &&
-                       Equals(p1.Value.LabelValueSet, p2.Value.LabelValueSet,
-                           (a,b) => a.Values.OrderBy(e => e).SequenceEqual(b.Values.OrderBy(e => e)));
+                       AreEqual(p1.Value.LabelValueSet, p2.Value.LabelValueSet, LabelValueSetComparer.CompareNonNull);
             }
-            
-            private bool Equals<T>(T a, T b, Func<T,T,bool> nonNullEquals)
-            {
-                if (ReferenceEquals(a, null) && ReferenceEquals(b, null))
-                    return true;
-                
-                if (ReferenceEquals(a, null) || ReferenceEquals(b, null))
-                    return false;
+        }
 
-                return nonNullEquals(a, b);
+        public class LabelValueSetComparer : IComparer<LabelValueSet>
+        {
+            public int Compare(LabelValueSet l1, LabelValueSet l2)
+            {
+                return AreEqual(l1, l2, CompareNonNull) ? 0 : 1;
             }
+
+            internal static bool CompareNonNull(LabelValueSet l1, LabelValueSet l2)
+            {
+                return l1.Values.OrderBy(e => e)
+                    .SequenceEqual(l2.Values.OrderBy(e => e));
+            }
+        }
+        
+        private static bool AreEqual<T>(T a, T b, Func<T,T,bool> nonNullEquals)
+        {
+            if (ReferenceEquals(a, null) && ReferenceEquals(b, null))
+                return true;
+                
+            if (ReferenceEquals(a, null) || ReferenceEquals(b, null))
+                return false;
+
+            return nonNullEquals(a, b);
         }
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Properties now support multiple label values at a given effective time. Previously the value could be a single label or metric.

Initially multi-value properties are supported on portfolios only.

The corresponding Property Definition must have a ConstraintStyle of "Collection". Add multiple values using a PropertyValue containing a LabelValueSet.
