### PR TITLE
Disable sonar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
   export FBN_APP_NAME="${!fbn_app_name}"
 
   # run sonar
-  sonar-scanner
+#   sonar-scanner
 
 notifications:
   slack:


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Temporarily disable sonar as there is a situation where SDK tests can fail but sonar passes resulting in travis thinking the build is successful. The sonar and sdk runs need to split into separate tasks
