### PR TITLE
DEV-9094 : adjustments to local Sdk in migration of lusid instruments endpoints

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Transactions.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Transactions.cs
@@ -122,9 +122,10 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                 {
                     ["ClientInternal"] = new InstrumentIdValue(value: "SW-1")
                 },
-                definition: new InstrumentEconomicDefinition(
-                    instrumentFormat: "CustomFormat",
-                    content: "<customFormat>upload in custom xml or JSON format</customFormat>"
+                definition: new ExoticInstrument(
+                    instrumentFormat: new InstrumentDefinitionFormat("CustomSource", "CustomFormat", "0.1.2"),
+                    content: "<customFormat>the definition of the swap uploaded in custom Xml or Json format. One would expect that it should contain the full custom swap detail.</customFormat>",
+                    instrumentType: LusidInstrument.InstrumentTypeEnum.ExoticInstrument
                 ));
             
             //    create the swap

--- a/sdk/Lusid.Sdk.Tests/tutorials/Instruments/ComplexInstruments.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Instruments/ComplexInstruments.cs
@@ -149,7 +149,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
             // CREATE an exotic instrument (that can then be upserted into LUSID)
             var exotic = new ExoticInstrument(
                 instrumentFormat: new InstrumentDefinitionFormat("source", "someVendor", "1.1"),
-                content: "exoticInstrument",
+                content: "{\"data\":\"exoticInstrument\"}",
                 instrumentType: LusidInstrument.InstrumentTypeEnum.ExoticInstrument
             );
 
@@ -212,7 +212,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
         private void UpsertOtcToLusid(LusidInstrument instrument, string name, string idUniqueToInstrument)
         {
             // PACKAGE instrument for upsert
-            var instrumentDefinition = new LusidInstrumentDefinition(
+            var instrumentDefinition = new InstrumentDefinition(
                 name: name,
                 identifiers: new Dictionary<string, InstrumentIdValue>
                 {
@@ -222,7 +222,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
                 );
 
             // put instrument into Lusid
-            var response = _instrumentsApi.UpsertLusidInstruments(new Dictionary<string, LusidInstrumentDefinition>
+            var response = _instrumentsApi.UpsertInstruments(new Dictionary<string, InstrumentDefinition>
             {
                 ["someId1"] = instrumentDefinition
             });
@@ -234,7 +234,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
 
         private LusidInstrument QueryOtcFromLusid(string idUniqueToInstrument)
         {
-            var response = _instrumentsApi.GetLusidInstruments("ClientInternal",
+            var response = _instrumentsApi.GetInstruments("ClientInternal",
                 new List<string>
                 {
                     idUniqueToInstrument

--- a/sdk/Lusid.Sdk.Tests/tutorials/MarketData/Instruments.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/MarketData/Instruments.cs
@@ -268,11 +268,12 @@ namespace Lusid.Sdk.Tests.Tutorials.MarketData
                 },
                 
                 //  The details for valuing the instrument
-                definition: new InstrumentEconomicDefinition(
+                definition: new ExoticInstrument(
                     
                     //  Identifies which valuation engine to use
-                    instrumentFormat: "CustomFormat",
-                    content: "<customFormat>upload in custom xml or JSON format</customFormat>"
+                    instrumentFormat: new InstrumentDefinitionFormat("CustomSource", "CustomFormat", "0.1.2"),
+                    content: "<customFormat>upload in custom xml or JSON format</customFormat>",
+                    instrumentType: LusidInstrument.InstrumentTypeEnum.ExoticInstrument
                 ));
             
             //    create the swap


### PR DESCRIPTION
When initially added the lusid instrument model didn't exist for management of exotic instruments. As it now does, the upsert/delete/list end points for lusid instruments are now being migrated to the appropriate lusid instrument base class.


# Pull Request Checklist

- [ ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
