### PR TITLE
SE-400 Updated the refresh token logic so that even if both the acces…

### DIFF
--- a/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
+++ b/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
@@ -108,6 +108,33 @@ namespace Lusid.Sdk.Tests
             //    all requests must have the same token i.e. reuse a valid token
             Assert.That(requests.GroupBy(r => r.Result).Count(), Is.EqualTo(1), "Requests have different tokens");
         }
+        
+        [Test]
+        public async Task CanGetNewTokenWhenRefreshTokenExpired()
+        {
+            
+            var provider = new ClientCredentialsFlowTokenProvider(ApiConfig.Value);
+            var _ = await provider.GetAuthenticationTokenAsync();
+            var firstTokenDetails = provider.GetLastToken();
+
+            Assert.That(firstTokenDetails.RefreshToken, Is.Not.Null.And.Not.Empty, "refresh_token not returned so unable to verify refresh behaviour.");
+
+            Console.WriteLine($"Token expiring at {firstTokenDetails.ExpiresOn:o}");
+
+            // WHEN we pretend to delay until both...
+            // (1) the original token has expired (for expediency update the expires_on on the token)
+            provider.ExpireToken();
+            // (2) the refresh token has expired (for expediency update the refresh_token to an invalid value that will not be found)
+            provider.GetLastToken().RefreshToken = "InvalidRefreshToken";
+
+            Assert.That(DateTimeOffset.UtcNow, Is.GreaterThan(firstTokenDetails.ExpiresOn));
+            var refreshedToken = await provider.GetAuthenticationTokenAsync();
+
+            // THEN it should be populated, and the ExpiresOn should be in the future
+            Assert.That(refreshedToken, Is.Not.Empty);
+            Assert.That(provider.GetLastToken().ExpiresOn, Is.GreaterThan(DateTimeOffset.UtcNow));
+        }
+
     }
 }
 

--- a/sdk/Lusid.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
+++ b/sdk/Lusid.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
@@ -45,7 +46,7 @@ namespace Lusid.Sdk.Utilities
             }
             public string Token { get; }
             public DateTimeOffset ExpiresOn { get; internal set; }
-            public string RefreshToken { get; }
+            public string RefreshToken { get; internal set; }
         }
 
         
@@ -185,6 +186,11 @@ namespace Lusid.Sdk.Utilities
                 var response = await httpClient.SendAsync(tokenRequest);
                 var body = await response.Content.ReadAsStringAsync();
 
+                if (response.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    // Unable to refresh token so obtain a brand new one using username/password 
+                    return await GetNewToken(apiConfig);
+                } 
                 if (!response.IsSuccessStatusCode)
                 {
                     throw new HttpRequestException(
@@ -231,5 +237,6 @@ namespace Lusid.Sdk.Utilities
         {
             _lastIssuedToken.ExpiresOn = DateTimeOffset.UtcNow.AddSeconds(-1);
         }
+
     }
 }


### PR DESCRIPTION
…s token and refresh token are expired a new access token can be generated from Okta

# Pull Request Checklist

- [x] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
