### PR TITLE
DEV-9680: Prepared SDK error message tests for new ValidationAttributes

### DIFF
--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -119,7 +119,7 @@ namespace Lusid.Sdk.Tests
         }
         
         [Test]
-        public void ApiException_Converts_To_ValidationProblemDetails()
+        public void ApiException_Converts_To_ValidationProblemDetails_AllowedRegex()
         {
             try
             {
@@ -134,14 +134,48 @@ namespace Lusid.Sdk.Tests
                 {
                     //Should identify that there was a validation error with the code
                     Assert.That(errorResponse.Errors, Contains.Key("code"));
-                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for this field must be non-zero in length and be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the LUSID documentation."));
+                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for the field code must be comprised of either alphanumeric characters, hyphens or underscores (matching the regular expression '^[a-zA-Z0-9\\\\-_]+$'). For more information please consult the documentation."));
                     
                     //Should identify that there was a validation error with the scope
                     Assert.That(errorResponse.Errors, Contains.Key("scope"));
-                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for this field must be non-zero in length and be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the LUSID documentation."));
+                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for the field scope must be comprised of either alphanumeric characters, hyphens or underscores (matching the regular expression '^[a-zA-Z0-9\\\\-_]+$'). For more information please consult the documentation."));
                 
                     Assert.That(errorResponse.Detail, Does.Match("One or more of the bits of input data provided were not valid.*"));
-                    Assert.That(errorResponse.Name, Is.EqualTo("InvalidParameterValue"));
+                    Assert.That(errorResponse.Name, Is.EqualTo("InvalidRequestFailure"));
+                }
+                else
+                {
+                    Assert.Fail("The request should have failed due to a validation error, and the validation details should be returned");
+                }
+            }
+        }
+        
+        [Test]
+        public void ApiException_Converts_To_ValidationProblemDetails_MaxLength()
+        {
+            try
+            {
+                var testScope = new string('a', 100);
+                var testCode = new string('b', 100);
+                var _ = _factory.Api<PortfoliosApi>().GetPortfolio(testScope, testCode);
+            }
+            catch (ApiException e)
+            {
+                Assert.That(e.IsValidationProblem, Is.True, "Response should indicate that there was a validation error with the request");
+                
+                //    An ApiException.ErrorContent thrown because of a request validation contains a JSON serialized LusidValidationProblemDetails
+                if (e.TryGetValidationProblemDetails(out var errorResponse))
+                {
+                    //Should identify that there was a validation error with the code
+                    Assert.That(errorResponse.Errors, Contains.Key("code"));
+                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for the field code must be non-zero in length and have no more than 64 characters. For more information please consult the documentation."));
+                    
+                    //Should identify that there was a validation error with the scope
+                    Assert.That(errorResponse.Errors, Contains.Key("scope"));
+                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for the field scope must be non-zero in length and have no more than 64 characters. For more information please consult the documentation."));
+                
+                    Assert.That(errorResponse.Detail, Does.Match("One or more of the bits of input data provided were not valid.*"));
+                    Assert.That(errorResponse.Name, Is.EqualTo("InvalidRequestFailure"));
                 }
                 else
                 {

--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -134,11 +134,11 @@ namespace Lusid.Sdk.Tests
                 {
                     //Should identify that there was a validation error with the code
                     Assert.That(errorResponse.Errors, Contains.Key("code"));
-                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for the field code must be comprised of either alphanumeric characters, hyphens or underscores (matching the regular expression '^[a-zA-Z0-9\\\\-_]+$'). For more information please consult the documentation."));
+                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for the field code must be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the documentation."));
                     
                     //Should identify that there was a validation error with the scope
                     Assert.That(errorResponse.Errors, Contains.Key("scope"));
-                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for the field scope must be comprised of either alphanumeric characters, hyphens or underscores (matching the regular expression '^[a-zA-Z0-9\\\\-_]+$'). For more information please consult the documentation."));
+                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for the field scope must be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the documentation."));
                 
                     Assert.That(errorResponse.Detail, Does.Match("One or more of the bits of input data provided were not valid.*"));
                     Assert.That(errorResponse.Name, Is.EqualTo("InvalidRequestFailure"));


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Changed the scope and code error messages according to the new messages that are going to be sent after DEV-9680 is merged on LUSID
