### PR TITLE
WEAL-1069: Guard against null reference exceptions when calling GetRequestId

### DIFF
--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -253,6 +253,15 @@ namespace Lusid.Sdk.Tests
         }
         
         [Test]
+        public void ApiException_Without_ErrorContent_Returns_NullRequestId()
+        {
+            var error = new ApiException();
+            var errorResponse = error.GetRequestId();
+            
+            Assert.That(errorResponse, Is.Null);
+        }
+        
+        [Test]
         public void ApiException_With_Empty_ErrorContent_Returns_Null()
         {
             var error = new ApiException();

--- a/sdk/Lusid.Sdk/Utilities/ApiExceptionExtensions.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiExceptionExtensions.cs
@@ -73,6 +73,8 @@ namespace Lusid.Sdk.Utilities
         /// </summary>
         public static string GetRequestId(this ApiException ex)
         {
+            if (ex.ProblemDetails() == null) return null;
+
             // Extract requestId from Insights link contained in the Instance property
             var instanceParts = ex.ProblemDetails().Instance.Split("/".ToCharArray());
 


### PR DESCRIPTION
The current implementation of GetRequestId throws an exception if the `ex.ErrorContent == null`. This merge request adds a null check before proceeding. 