### PR TITLE
DEV-11188: update timeout mechanism, and add longer timeout for orders test

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Orders.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Orders.cs
@@ -268,6 +268,10 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
         [Test]
         public void Upsert_And_Retrieve_Simple_Orders()
         {
+            // DEV-: this is a long-runner until we get PropertyWarehouse and entity index changes in
+            var originalTimeout = _ordersApi.Configuration.Timeout;
+            _ordersApi.Configuration.Timeout = 200000;
+
             var testScope = TutorialScopes["filtering"];
             var order1 = $"Order-{Guid.NewGuid().ToString()}";
             var order2 = $"Order-{Guid.NewGuid().ToString()}";
@@ -396,6 +400,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
             Assert.That(sideFilter.Values.All(rl => rl.Side.Equals("Sell")));
             */
 
+            _ordersApi.Configuration.Timeout = originalTimeout;
         } 
     } 
 }

--- a/sdk/Lusid.Sdk/Client/ApiClient.cs
+++ b/sdk/Lusid.Sdk/Client/ApiClient.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using RestSharp.Portable;
 using RestSharp.Portable.HttpClient;
@@ -174,13 +175,16 @@ namespace Lusid.Sdk.Client
                 pathParams, contentType);
 
             // set timeout
-            RestClient.Timeout = TimeSpan.FromMilliseconds(Configuration.Timeout);
+            // RestSharp seems to suffer from ignored timeouts (google: "restsharp timeout ignored")
+            // And this is a derived lib (FubarCoder); this approach taken from:
+            // https://github.com/FubarDevelopment/restsharp.portable/issues/13
+            var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(Configuration.Timeout));
             
             // set user agent
             RestClient.UserAgent = Configuration.UserAgent;
 
             InterceptRequest(request);
-            var response = RestClient.Execute(request).Result;
+            var response = RestClient.Execute(request, cts.Token).Result;
             InterceptResponse(request, response);
 
             return (Object) response;


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [X] Raised the PR against the `develop` branch

# Description of the PR

One orders test is very long running, and will remain so until we complete some property warehouse and derived entity index work on the underlying LUSID stack. It now times out in CI tests. We want to extend the timeout, but there's some complexity (and apparently buggy behaviour) around RestSharp client and request timeouts - and we're using a derived library from FubarCoder.

Followed advice from https://github.com/FubarDevelopment/restsharp.portable/issues/13 to control timeout in a slightly heavy-handed way.
