### PR TITLE
SE-1215 added FBN_ACCESS_TOKEN implementation

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -42,6 +42,7 @@ jobs:
           FBN_CLIENT_SECRET: ${{ secrets.DEVELOP_FBN_CLIENT_SECRET }}
           FBN_LUSID_API_URL: ${{ secrets.DEVELOP_FBN_LUSID_API_URL }}
           FBN_APP_NAME: ${{ secrets.DEVELOP_FBN_CLIENT_ID }}
+          FBN_ACCESS_TOKEN: ${{ secrets.DEVELOP_FBN_ACCESS_TOKEN }}
         run: |
           echo "env variables for DEVELOP have been set"
           echo "Changing directory into sdk directory"
@@ -60,6 +61,7 @@ jobs:
           FBN_CLIENT_SECRET: ${{ secrets.MASTER_FBN_CLIENT_SECRET }}
           FBN_LUSID_API_URL: ${{ secrets.MASTER_FBN_LUSID_API_URL }}
           FBN_APP_NAME: ${{ secrets.MASTER_FBN_CLIENT_ID }}
+          FBN_ACCESS_TOKEN: ${{ secrets.MASTER_FBN_ACCESS_TOKEN }}
         run: | 
           echo "env variables for MASTER have been set"
           echo "Changing directory into sdk directory"

--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -85,7 +84,8 @@ namespace Lusid.Sdk.Tests
         {
             ApiConfiguration apiConfig = new ApiConfiguration
             {
-                TokenUrl = "xyz"
+                TokenUrl = "xyz",
+                ApiUrl = "http://abc" // api uri is checked first and must pass
             };
 
             Assert.That(
@@ -279,6 +279,43 @@ namespace Lusid.Sdk.Tests
         {
             var config = TestLusidApiFactoryBuilder.CreateApiConfiguration("secrets.json");
             var provider = new ClientCredentialsFlowTokenProvider(config);
+            
+            var date = new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+            var request = Enumerable.Range(0, quoteCount).Select(i => new UpsertQuoteRequest(
+                new QuoteId(
+                    new QuoteSeriesId(
+                        provider: "DataScope",
+                        priceSource: "BankA",
+                        instrumentId: "BBG000B9XRY4",
+                        instrumentIdType: QuoteSeriesId.InstrumentIdTypeEnum.Figi,
+                        quoteType: QuoteSeriesId.QuoteTypeEnum.Price,
+                        field: "mid"),
+                    effectiveAt: date.AddDays(i)),
+                metricValue: new MetricValue(
+                    value: 199.23m,
+                    unit: "USD"),
+                lineage: "InternalSystem")).ToDictionary(k => k.QuoteId.EffectiveAt.ToString(), v => v);
+
+            var tasks = Enumerable.Range(0, threadCount).Select(x => Task.Run(() =>
+            {
+                var factory = LusidApiFactoryBuilder.Build(config.ApiUrl, provider);
+                var result = factory.Api<IQuotesApi>().UpsertQuotes("mt-scope", request);
+                Assert.That(result.Failed, Is.Empty);
+                
+                Console.WriteLine($"{DateTimeOffset.UtcNow} {Thread.CurrentThread.ManagedThreadId} {result.Values.Count}");
+            }));
+
+            Task.WaitAll(tasks.ToArray());
+        }
+        
+        
+        [TestCase(1, 10)]
+        [TestCase(100, 25, Explicit = true)]
+        public void Multi_Threaded_ApiFactory_Tasks_WithPACToken(int quoteCount, int threadCount)
+        {
+            var config = ApiConfigurationBuilder.Build("secrets.json");
+            var provider = new PersonalAccessTokenProvider(config.PersonalAccessToken);
             
             var date = new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero);
 

--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -314,7 +314,7 @@ namespace Lusid.Sdk.Tests
         [TestCase(100, 25, Explicit = true)]
         public void Multi_Threaded_ApiFactory_Tasks_WithPACToken(int quoteCount, int threadCount)
         {
-            var config = ApiConfigurationBuilder.Build("secrets.json");
+            var config = ApiConfigurationBuilder.Build(null);
             var provider = new PersonalAccessTokenProvider(config.PersonalAccessToken);
             
             var date = new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
+++ b/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
@@ -28,6 +28,19 @@ namespace Lusid.Sdk.Tests
             // THEN it is populated
             Assert.That(token, Is.Not.Empty);
         }
+        
+        [Test]
+        public async Task CanGetPACToken()
+        {
+            // GIVEN a token provider initialised with required secrets
+            var provider = new PersonalAccessTokenProvider(ApiConfig.Value.PersonalAccessToken);
+
+            // WHEN the token is requested
+            var token = await provider.GetAuthenticationTokenAsync();
+
+            // THEN it is populated
+            Assert.That(token, Is.Not.Empty);
+        }
 
         [Test]
         public async Task CanRefreshWithRefreshToken()
@@ -109,6 +122,23 @@ namespace Lusid.Sdk.Tests
             //    all requests must have the same token i.e. reuse a valid token
             Assert.That(requests.GroupBy(r => r.Result).Count(), Is.EqualTo(1), "Requests have different tokens");
         }
+        
+        [Test]
+        public void Can_Retrieve_Same_PACToken_From_Multiple_Threads()
+        {
+            const int threadCount = 100;
+            
+            //    create threads with calls to get a token
+            var providers = Enumerable.Repeat(new PersonalAccessTokenProvider(ApiConfig.Value.PersonalAccessToken), threadCount).ToList();
+            var requests = providers.Select(p => p.GetAuthenticationTokenAsync());
+
+            //    get the tokens
+            Task.WaitAll(requests.ToArray());
+
+            //    all requests must have the same token i.e. reuse a valid token
+            Assert.That(requests.GroupBy(r => r.Result).Count(), Is.EqualTo(1), "Requests have different tokens");
+        }
+
         
         [Test]
         public async Task CanGetNewTokenWhenRefreshTokenExpired()

--- a/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
+++ b/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
@@ -30,7 +30,7 @@ namespace Lusid.Sdk.Tests
         }
         
         [Test]
-        public async Task CanGetPACToken()
+        public async Task CanGetPersonalAccessToken()
         {
             // GIVEN a token provider initialised with required secrets
             var provider = new PersonalAccessTokenProvider(ApiConfig.Value.PersonalAccessToken);
@@ -124,7 +124,7 @@ namespace Lusid.Sdk.Tests
         }
         
         [Test]
-        public void Can_Retrieve_Same_PACToken_From_Multiple_Threads()
+        public void Can_Retrieve_Same_PersonalAccessToken_From_Multiple_Threads()
         {
             const int threadCount = 100;
             

--- a/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationBuilderTest.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationBuilderTest.cs
@@ -137,7 +137,8 @@ namespace Lusid.Sdk.Tests.Utilities
             Environment.SetEnvironmentVariable("FBN_USERNAME", "<env.username>");
             Environment.SetEnvironmentVariable("FBN_PASSWORD", "");
             Environment.SetEnvironmentVariable("FBN_APP_NAME", "<env.app_name>");
-
+            Environment.SetEnvironmentVariable("FBN_ACCESS_TOKEN", "");
+            
             var exception = Assert.Throws<MissingConfigException>(() => ApiConfigurationBuilder.Build(null));
             Assert.That(exception.Message,
                 Is.EqualTo(

--- a/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationTest.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationTest.cs
@@ -35,7 +35,7 @@ namespace Lusid.Sdk.Tests.Utilities
         {
             var config = new ApiConfiguration() {ApiUrl = "http://bla.com", Username = "un", Password = "pwd", ClientId = "cid", ClientSecret = "cs", TokenUrl = "tu"};
             Assert.IsFalse(config.HasMissingConfig());
-            Assert.AreEqual("", string.Join(",", config.GetMissingConfig()));
+            Assert.AreEqual(string.Empty, string.Join(",", config.GetMissingConfig()));
         }
     }
 }

--- a/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationTest.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationTest.cs
@@ -1,0 +1,41 @@
+﻿using Lusid.Sdk.Utilities;
+using NUnit.Framework;
+
+namespace Lusid.Sdk.Tests.Utilities
+{
+    [TestFixture]
+    public class ApiConfigurationTest
+    {
+        [Test]
+        public void TestHasMissingPatConfig()
+        {
+            var config = new ApiConfiguration() {PersonalAccessToken = "token"};
+            Assert.IsTrue(config.HasMissingConfig());
+            Assert.AreEqual("ApiUrl", string.Join(",", config.GetMissingConfig()));
+        }
+
+        [Test]
+        public void TestHasCompletePatConfig()
+        {
+            var config = new ApiConfiguration() {PersonalAccessToken = "token", ApiUrl = "http://bla.com"};
+            Assert.IsFalse(config.HasMissingConfig());
+            Assert.AreEqual("", string.Join(",", config.GetMissingConfig()));
+        }
+
+        [Test]
+        public void TestHasMissingSecretsConfig()
+        {
+            var config = new ApiConfiguration() {ApiUrl = "http://bla.com"};
+            Assert.IsTrue(config.HasMissingConfig());
+            Assert.AreEqual("TokenUrl,Username,Password,ClientId,ClientSecret", string.Join(",", config.GetMissingConfig()));
+        }
+        
+        [Test]
+        public void TestHasCompleteSecretsConfig()
+        {
+            var config = new ApiConfiguration() {ApiUrl = "http://bla.com", Username = "un", Password = "pwd", ClientId = "cid", ClientSecret = "cs", TokenUrl = "tu"};
+            Assert.IsFalse(config.HasMissingConfig());
+            Assert.AreEqual("", string.Join(",", config.GetMissingConfig()));
+        }
+    }
+}

--- a/sdk/Lusid.Sdk/Utilities/ApiConfiguration.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiConfiguration.cs
@@ -43,17 +43,28 @@ namespace Lusid.Sdk.Utilities
         public string ApplicationName { get; set; }
         
         /// <summary>
+        /// Configurable via FBN_ACCESS_TOKEN env variable - get the value from LUSID web 'Your Profile'->'Personal access tokens'.
+        /// Takes precedence over other authentication factors if set.
+        /// </summary>
+        public string PersonalAccessToken { get; set; }
+        
+        /// <summary>
         /// Checks if any of the required configuration values are missing
         /// </summary>
         /// <returns></returns>
         public bool HasMissingConfig()
         {
-            return string.IsNullOrEmpty(TokenUrl) ||
-                   string.IsNullOrEmpty(Username) ||
-                   string.IsNullOrEmpty(Password) ||
-                   string.IsNullOrEmpty(ClientId) ||
-                   string.IsNullOrEmpty(ClientSecret) ||
-                   string.IsNullOrEmpty(ApiUrl);
+            var noPersonalAccessTokenVariablesPresent = string.IsNullOrEmpty(PersonalAccessToken) ||
+                                                        string.IsNullOrEmpty(ApiUrl);
+            
+            var noEnvironmentVariablesPresent =  string.IsNullOrEmpty(TokenUrl) ||
+                                                 string.IsNullOrEmpty(Username) ||
+                                                 string.IsNullOrEmpty(Password) ||
+                                                 string.IsNullOrEmpty(ClientId) ||
+                                                 string.IsNullOrEmpty(ClientSecret) ||
+                                                 string.IsNullOrEmpty(ApiUrl);
+
+            return noPersonalAccessTokenVariablesPresent && noEnvironmentVariablesPresent;
         }
 
         /// <summary>
@@ -86,6 +97,10 @@ namespace Lusid.Sdk.Utilities
             if (string.IsNullOrEmpty(ApiUrl))
             {
                 missingConfig.Add("ApiUrl");
+            }
+            if (string.IsNullOrEmpty(PersonalAccessToken))
+            {
+                missingConfig.Add("PersonalAccessToken");
             }
             return missingConfig;
         }

--- a/sdk/Lusid.Sdk/Utilities/ApiConfiguration.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiConfiguration.cs
@@ -30,7 +30,7 @@ namespace Lusid.Sdk.Utilities
         /// <summary>
         /// OAuth2 Client Secret
         /// </summary>
-        public string ClientSecret { get;  set; }
+        public string ClientSecret { get; set; }
 
         /// <summary>
         /// LUSID Api Url
@@ -41,67 +41,81 @@ namespace Lusid.Sdk.Utilities
         /// Client Application name
         /// </summary>
         public string ApplicationName { get; set; }
-        
+
         /// <summary>
         /// Configurable via FBN_ACCESS_TOKEN env variable - get the value from LUSID web 'Your Profile'->'Personal access tokens'.
         /// Takes precedence over other authentication factors if set.
         /// </summary>
         public string PersonalAccessToken { get; set; }
-        
+
+        private bool MissingPersonalAccessTokenVariables =>
+            string.IsNullOrEmpty(PersonalAccessToken) ||
+            string.IsNullOrEmpty(ApiUrl);
+
+        private bool MissingSecretVariables =>
+            string.IsNullOrEmpty(TokenUrl) ||
+            string.IsNullOrEmpty(Username) ||
+            string.IsNullOrEmpty(Password) ||
+            string.IsNullOrEmpty(ClientId) ||
+            string.IsNullOrEmpty(ClientSecret) ||
+            string.IsNullOrEmpty(ApiUrl);
+
         /// <summary>
         /// Checks if any of the required configuration values are missing
         /// </summary>
         /// <returns></returns>
         public bool HasMissingConfig()
         {
-            var noPersonalAccessTokenVariablesPresent = string.IsNullOrEmpty(PersonalAccessToken) ||
-                                                        string.IsNullOrEmpty(ApiUrl);
-            
-            var noEnvironmentVariablesPresent =  string.IsNullOrEmpty(TokenUrl) ||
-                                                 string.IsNullOrEmpty(Username) ||
-                                                 string.IsNullOrEmpty(Password) ||
-                                                 string.IsNullOrEmpty(ClientId) ||
-                                                 string.IsNullOrEmpty(ClientSecret) ||
-                                                 string.IsNullOrEmpty(ApiUrl);
-
-            return noPersonalAccessTokenVariablesPresent && noEnvironmentVariablesPresent;
+            return MissingPersonalAccessTokenVariables && MissingSecretVariables;
         }
 
         /// <summary>
         /// Returns a list of the missing required configuration values
         /// </summary>
         /// <returns></returns>
-        public List<string> MissingConfig()
+        public List<string> GetMissingConfig()
         {
             var missingConfig = new List<string>();
+
+            if (!string.IsNullOrEmpty(PersonalAccessToken))
+            {
+                if (MissingPersonalAccessTokenVariables)
+                {
+                    missingConfig.Add("ApiUrl");
+                }
+                return missingConfig; // in case PAC is to be used we don't care about the other properties
+            }
+
             if (string.IsNullOrEmpty(TokenUrl))
             {
                 missingConfig.Add("TokenUrl");
             }
+
             if (string.IsNullOrEmpty(Username))
             {
                 missingConfig.Add("Username");
             }
+
             if (string.IsNullOrEmpty(Password))
             {
                 missingConfig.Add("Password");
             }
+
             if (string.IsNullOrEmpty(ClientId))
             {
                 missingConfig.Add("ClientId");
             }
+
             if (string.IsNullOrEmpty(ClientSecret))
             {
                 missingConfig.Add("ClientSecret");
-            } 
+            }
+
             if (string.IsNullOrEmpty(ApiUrl))
             {
                 missingConfig.Add("ApiUrl");
             }
-            if (string.IsNullOrEmpty(PersonalAccessToken))
-            {
-                missingConfig.Add("PersonalAccessToken");
-            }
+
             return missingConfig;
         }
     }

--- a/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
@@ -42,7 +42,7 @@ namespace Lusid.Sdk.Utilities
         /// <returns></returns>
         public static ApiConfiguration Build(string apiSecretsFilename)
         {
-            return apiSecretsFilename == null || !File.Exists(apiSecretsFilename)
+            return apiSecretsFilename == null
                 ? BuildFromEnvironmentVariables()
                 : BuildFromSecretsFile(apiSecretsFilename);
         }

--- a/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
@@ -19,6 +19,7 @@ namespace Lusid.Sdk.Utilities
             {"ClientSecret", "FBN_CLIENT_SECRET"},
             {"Username", "FBN_USERNAME"},
             {"Password", "FBN_PASSWORD"},
+            {"PersonalAccessToken", "FBN_ACCESS_TOKEN"}
         };
         
         private static readonly Dictionary<string, string> ConfigNamesToSecrets = new Dictionary<string, string>()
@@ -28,7 +29,7 @@ namespace Lusid.Sdk.Utilities
             {"ClientId", "clientId"},
             {"ClientSecret", "clientSecret"},
             {"Username", "username"},
-            {"Password", "password"},
+            {"Password", "password"}
         };
         
         /// <summary>
@@ -41,7 +42,7 @@ namespace Lusid.Sdk.Utilities
         /// <returns></returns>
         public static ApiConfiguration Build(string apiSecretsFilename)
         {
-            return apiSecretsFilename == null
+            return apiSecretsFilename == null || !File.Exists(apiSecretsFilename)
                 ? BuildFromEnvironmentVariables()
                 : BuildFromSecretsFile(apiSecretsFilename);
         }
@@ -71,7 +72,7 @@ namespace Lusid.Sdk.Utilities
             
             if (apiConfig.HasMissingConfig())
             {
-                var missingValues = apiConfig.MissingConfig()
+                var missingValues = apiConfig.GetMissingConfig()
                     .Select(value => $"'{ConfigNamesToEnvVariables[value]}'");
                 var message = $"[{string.Join(", ", missingValues)}]";
                 throw new MissingConfigException($"The following required environment variables are not set: {message}");
@@ -93,7 +94,7 @@ namespace Lusid.Sdk.Utilities
 
             if (apiConfig.HasMissingConfig())
             {
-                var missingValues = apiConfig.MissingConfig()
+                var missingValues = apiConfig.GetMissingConfig()
                     .Select(value => $"'{ConfigNamesToSecrets[value]}'");
                 var message = $"[{string.Join(", ", missingValues)}]";
                 throw new MissingConfigException($"The provided secrets file is missing the following required values: {message}");

--- a/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
@@ -64,7 +64,9 @@ namespace Lusid.Sdk.Utilities
                 Password = Environment.GetEnvironmentVariable("FBN_PASSWORD") ??
                            Environment.GetEnvironmentVariable("fbn_password"),
                 ApplicationName = Environment.GetEnvironmentVariable("FBN_APP_NAME") ??
-                                  Environment.GetEnvironmentVariable("fbn_app_name")
+                                  Environment.GetEnvironmentVariable("fbn_app_name"),
+                PersonalAccessToken = Environment.GetEnvironmentVariable("FBN_ACCESS_TOKEN") ?? 
+                                Environment.GetEnvironmentVariable("fbn_access_token")
             };
             
             if (apiConfig.HasMissingConfig())

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
@@ -33,19 +33,27 @@ namespace Lusid.Sdk.Utilities
         {
             if (apiConfiguration == null) throw new ArgumentNullException(nameof(apiConfiguration));
 
-            // Validate Uris
-            if (!Uri.TryCreate(apiConfiguration.TokenUrl, UriKind.Absolute, out var _))
-            {
-                throw new UriFormatException($"Invalid Token Uri: {apiConfiguration.TokenUrl}");
-            }
-
             if (!Uri.TryCreate(apiConfiguration.ApiUrl, UriKind.Absolute, out var _))
             {
                 throw new UriFormatException($"Invalid LUSID Uri: {apiConfiguration.ApiUrl}");
             }
 
+            // note: could employ a factory pattern here to create ITokenProvider in case more branching is required in the future:
+            ITokenProvider tokenProvider;
+            if (!string.IsNullOrEmpty(apiConfiguration.PersonalAccessToken)) // the personal access token takes precedence over other methods of authentication
+            {
+                tokenProvider = new PersonalAccessTokenProvider(apiConfiguration.PersonalAccessToken);
+            }
+            else
+            {                
+                if (!Uri.TryCreate(apiConfiguration.TokenUrl, UriKind.Absolute, out var _))
+                {
+                    throw new UriFormatException($"Invalid Token Uri: {apiConfiguration.TokenUrl}");
+                }
+                tokenProvider = new ClientCredentialsFlowTokenProvider(apiConfiguration);    
+            }
+            
             // Create configuration
-            var tokenProvider = new ClientCredentialsFlowTokenProvider(apiConfiguration);
             var configuration = new TokenProviderConfiguration(tokenProvider)
             {
                 BasePath = apiConfiguration.ApiUrl,

--- a/sdk/Lusid.Sdk/Utilities/PersonalAccessTokenProvider.cs
+++ b/sdk/Lusid.Sdk/Utilities/PersonalAccessTokenProvider.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Lusid.Sdk.Utilities
+{
+    /// <summary>
+    /// Provides a PersonalAccessTokenProvider from an environment variable
+    /// </summary>
+    public class PersonalAccessTokenProvider : ITokenProvider
+    {
+        private string _token;
+        
+        /// <summary>
+        /// Implementation of a TokenProvider for use with a Personal Access Token - generated in LUSID web and used in a FBN_ACCESS_TOKEN env variable.
+        /// </summary>
+        /// <param name="personalAccessToken">the token to use</param>
+        /// <remarks>FBN_LUSID_API_URL env variable will also need to be defined in order to use this approach</remarks>
+        public PersonalAccessTokenProvider(string personalAccessToken)
+        {
+            if (string.IsNullOrEmpty(personalAccessToken))
+            {
+                throw new ArgumentException("Expected a non empty personal access token");
+            }
+            _token = personalAccessToken;
+        }
+        
+        /// <summary>
+        /// Gets the authentication token generated in LUSID web and stored as an env variable named FBN_ACCESS_TOKEN 
+        /// </summary>
+        /// <returns>the authentication token</returns>
+        public async Task<string> GetAuthenticationTokenAsync()
+        {
+            return await Task.FromResult(_token);
+        }
+
+        /// <summary>
+        /// Gets the authentication header.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderAsync()
+        {
+            string token = await this.GetAuthenticationTokenAsync();
+            return new AuthenticationHeaderValue("Bearer", token);
+        }
+    }
+}

--- a/sdk/docker-compose.yml
+++ b/sdk/docker-compose.yml
@@ -14,5 +14,6 @@ services:
       - FBN_CLIENT_SECRET
       - FBN_LUSID_API_URL
       - FBN_APP_NAME
+      - FBN_ACCESS_TOKEN
     volumes:
       - .:/usr/src


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

LUSID has support for Personal Access Tokens which can be used instead of acquiring Okta tokens though the OAuth or Authorisation flow

This is already supported by setting Configuration.AccessToken and passing to the LusidApiFactory(Configuration).

Added the ability to use the PAT (generated in LUSID) with the SDK and configured from env vars

Implemented a new PersonalAccessTokenProvider which implements ITokenProvider

Read the token from an env var set via FBN_ACCESS_TOKEN

Added PersonalAccessToken property to ApiConfiguration. If specified it takes precedence over the credentials 

Updated build pipeline with a PAT for both master and develop branches - stored as secrets and exposed via docker env variable. Values stored in LastPass for reference
