### PR TITLE
DEV-11249

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Orders.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Orders.cs
@@ -34,7 +34,9 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
             "OrderBook",
             "PortfolioManager",
             "Account",
-            "Strategy"
+            "Strategy",
+            "Scope",
+            "Code"
         };
 
         [OneTimeSetUp]
@@ -303,6 +305,8 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                             { $"Order/{testScope}/PortfolioManager", new PerpetualProperty($"Order/{testScope}/PortfolioManager", new PropertyValue("F Bar")) },
                             { $"Order/{testScope}/Account", new PerpetualProperty($"Order/{testScope}/Account", new PropertyValue("ZB123")) },
                             { $"Order/{testScope}/Strategy", new PerpetualProperty($"Order/{testScope}/Strategy", new PropertyValue("RiskArb")) },
+                            { $"Order/{testScope}/Scope", new PerpetualProperty($"Order/{testScope}/Scope", new PropertyValue(orderId1.Scope)) },
+                            { $"Order/{testScope}/Code", new PerpetualProperty($"Order/{testScope}/Code", new PropertyValue(orderId1.Code)) },
                         },
                         side: "Buy"
                     ),
@@ -327,6 +331,8 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                             { $"Order/{testScope}/PortfolioManager", new PerpetualProperty($"Order/{testScope}/PortfolioManager", new PropertyValue("F Bar")) },
                             { $"Order/{testScope}/Account", new PerpetualProperty($"Order/{testScope}/Account", new PropertyValue("J Wilson")) },
                             { $"Order/{testScope}/Strategy", new PerpetualProperty($"Order/{testScope}/Strategy", new PropertyValue("UK Growth")) },
+                            { $"Order/{testScope}/Scope", new PerpetualProperty($"Order/{testScope}/Scope", new PropertyValue(orderId2.Scope)) },
+                            { $"Order/{testScope}/Code", new PerpetualProperty($"Order/{testScope}/Code", new PropertyValue(orderId2.Code)) },
                         },
                         side: "Sell"
                     ),
@@ -351,6 +357,8 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
                             { $"Order/{testScope}/PortfolioManager", new PerpetualProperty($"Order/{testScope}/PortfolioManager", new PropertyValue("F Bar")) },
                             { $"Order/{testScope}/Account", new PerpetualProperty($"Order/{testScope}/Account", new PropertyValue("J Wilson")) },
                             { $"Order/{testScope}/Strategy", new PerpetualProperty($"Order/{testScope}/Strategy", new PropertyValue("RiskArb")) },
+                            { $"Order/{testScope}/Scope", new PerpetualProperty($"Order/{testScope}/Scope", new PropertyValue(orderId3.Scope)) },
+                            { $"Order/{testScope}/Code", new PerpetualProperty($"Order/{testScope}/Code", new PropertyValue(orderId3.Code)) },
                         },
                         side: "Buy"
                     )
@@ -370,9 +378,13 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
             var order2Filter = $"{order2}";
             var order3Filter = $"{order3}";
 
-            var quantityFilter = _ordersApi.ListOrders(asAt:
-                t,
-                filter: $"Quantity gt 100 and Id.Scope eq '{testScope}' and Id.Code in ('{order1}', '{order2}', '{order3}')");
+            var quantityFilter = _ordersApi.ListOrders(
+                asAt: t,
+                filter:
+                      $"Quantity gt 100 "
+                    + $"and properties.Order/{testScope}/Scope eq '{testScope}' "
+                    + $"and properties.Order/{testScope}/Code in ('{order1}', '{order2}', '{order3}')"
+                );
 
             Assert.That(quantityFilter.Values.Count, Is.EqualTo(2));
             Assert.That(quantityFilter.Values.All(rl => rl.Quantity > 100));


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

This test demonstrates filtering of order results. It should benefit from Elliot's recent migration of Orders to use the property warehouse but: the query it uses

1. uses `gt` rather than `eq` for quantity, meaning that it can't be used by the pre-query optimiser, and
2. also filters on scope and code - which aren't put into the properties set by default

It's likely that putting scope and code into the property set will enable the pre-filter query to do its job and avoid having to fetch everything before filtering.
