### PR TITLE
ApiConfigurationBuilder can be passed IConfigurationSection

### DIFF
--- a/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationBuilderTest.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationBuilderTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using Lusid.Sdk.Utilities;
+using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 
 namespace Lusid.Sdk.Tests.Utilities
@@ -10,7 +11,7 @@ namespace Lusid.Sdk.Tests.Utilities
     public class ApiConfigurationBuilderTest
     {
         private string _secretsFile;
-        
+
         private string _cachedTokenUrl;
         private string _cachedApiUrl;
         private string _cachedClientId;
@@ -52,7 +53,7 @@ namespace Lusid.Sdk.Tests.Utilities
             Environment.SetEnvironmentVariable("FBN_APP_NAME", _cachedApplicationName);
             File.Delete(_secretsFile);
         }
-        
+
         [Test]
         public void Throw_Exception_For_Missing_Secrets_File()
         {
@@ -71,7 +72,7 @@ namespace Lusid.Sdk.Tests.Utilities
                 {"clientSecret", "<clientSecret>"},
                 {"apiUrl", "<apiUrl>"},
             });
-            
+
             using var console = new InMemoryConsole();
             var apiConfiguration = ApiConfigurationBuilder.Build(_secretsFile);
 
@@ -142,6 +143,69 @@ namespace Lusid.Sdk.Tests.Utilities
             Assert.That(exception.Message,
                 Is.EqualTo(
                     "The following required environment variables are not set: ['FBN_PASSWORD', 'FBN_CLIENT_SECRET']"));
+        }
+
+        [Test]
+        public void Use_Configuration_Section_If_Supplied()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "api:TokenUrl", "<tokenUrl>" },
+                { "api:ApiUrl", "<apiUrl>" },
+                { "api:ClientId", "<clientId>" },
+                { "api:ClientSecret", "<clientSecret>" },
+                { "api:Username", "<username>" },
+                { "api:Password", "<password>" },
+                { "api:ApplicationName", "<app_name>" }
+            };
+
+            using var console = new InMemoryConsole();
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(settings)
+                .Build();
+            var section = config.GetSection("api");
+            var apiConfiguration = ApiConfigurationBuilder.BuildFromConfiguration(section);
+
+            Assert.That(apiConfiguration.TokenUrl, Is.EqualTo("<tokenUrl>"));
+            Assert.That(apiConfiguration.Username, Is.EqualTo("<username>"));
+            Assert.That(apiConfiguration.Password, Is.EqualTo("<password>"));
+            Assert.That(apiConfiguration.ClientId, Is.EqualTo("<clientId>"));
+            Assert.That(apiConfiguration.ClientSecret, Is.EqualTo("<clientSecret>"));
+            Assert.That(apiConfiguration.ApiUrl, Is.EqualTo("<apiUrl>"));
+
+            StringAssert.Contains($"Loaded values from configuration", console.GetOutput());
+        }
+
+        [Test]
+        public void Throw_Exception_If_Configuration_Section_Is_Null()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => ApiConfigurationBuilder.BuildFromConfiguration(null));
+            Assert.That(exception.Message, Is.EqualTo("Value cannot be null. (Parameter 'config')"));
+        }
+
+        [Test]
+        public void Throw_Exception_If_Configuration_Section_Incomplete()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "api:TokenUrl", "<tokenUrl>" },
+                { "api:ApiUrl", "<apiUrl>" },
+                { "api:ClientId", "<clientId>" },
+                { "api:ClientSecret", "" },
+                { "api:Username", "<username>" },
+                { "api:Password", "" },
+                { "api:ApplicationName", "<app_name>" }
+            };
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(settings)
+                .Build();
+            var section = config.GetSection("api");
+            var exception = Assert.Throws<MissingConfigException>(() => ApiConfigurationBuilder.BuildFromConfiguration(section));
+            Assert.That(exception.Message,
+                Is.EqualTo(
+                    "The provided configuration section is missing the following required values: ['Password', 'ClientSecret']"));
         }
 
         private void PopulateDummySecretsFile(Dictionary<string, string> config)

--- a/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
@@ -99,5 +99,31 @@ namespace Lusid.Sdk.Utilities
             
             return apiConfig;
         }
+
+        /// <summary>
+        /// Builds an ApiConfiguration using the supplied configuration section.
+        ///
+        /// For further details refer to https://github.com/finbourne/lusid-sdk-csharp/wiki/API-credentials
+        /// </summary>
+        /// <param name="config">section of ASP Core configuration with required fields</param>
+        /// <returns></returns>
+        public static ApiConfiguration BuildFromConfiguration(IConfigurationSection config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            Console.WriteLine($"Loaded values from configuration");
+
+            var apiConfig = new ApiConfiguration();
+            config.Bind(apiConfig);
+
+            if(apiConfig.HasMissingConfig())
+            {
+                var missingValues = apiConfig.MissingConfig()
+                    .Select(value => $"'{value}'");
+                var message = $"[{string.Join(", ", missingValues)}]";
+                throw new MissingConfigException($"The provided configuration section is missing the following required values: {message}");
+            }
+
+            return apiConfig;
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [X] Raised the PR against the `develop` branch

# Description of the PR

Adding option for ApiConfigurationBuilder to be passed an IConfigurationSection to allow consuming code to be more flexible with sourcing config from multiple sources.

I originally tried to overload with a .Build(IConfigurationSection) but the .Build(null) to pick up environment variables causes a compiler error as the type of null can't be inferred. I didn't want to propose an API breaking change so just went with a public .BuildFromConfiguration instead.