### PR TITLE
ANA-376: Updating stubTypes and removing duplicates. The stubType.Fro…

### DIFF
--- a/sdk/Lusid.Sdk.Tests/Utilities/InstrumentExamples.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/InstrumentExamples.cs
@@ -93,7 +93,7 @@ namespace Lusid.Sdk.Tests.Utilities
             // CREATE the leg definitions
             var fixedLegDef = new LegDefinition(
                 rateOrSpread: 0.02m, // fixed leg rate (swap rate)
-                stubType: "Front",
+                stubType: "ShortFront",
                 payReceive: "Pay",
                 notionalExchangeType: "None",
                 conventions: CreateExampleFlowConventions()
@@ -101,7 +101,7 @@ namespace Lusid.Sdk.Tests.Utilities
 
             var floatLegDef = new LegDefinition(
                 rateOrSpread: 0.05m, // float leg spread over curve rate, often zero
-                stubType: "Front",
+                stubType: "ShortFront",
                 payReceive: "Pay",
                 notionalExchangeType: "None",
                 conventions: CreateExampleFlowConventions(),

--- a/sdk/Lusid.Sdk.Tests/tutorials/Instruments/ComplexInstruments.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Instruments/ComplexInstruments.cs
@@ -344,7 +344,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
             // CREATE the leg definitions
             var fixedLegDef = new LegDefinition(
                 rateOrSpread: 0.05m, // fixed leg rate (swap rate)
-                stubType: "Front",
+                stubType: "ShortFront",
                 payReceive: "Pay",
                 notionalExchangeType: "None",
                 conventions: flowConventions
@@ -352,7 +352,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
 
             var floatLegDef = new LegDefinition(
                 rateOrSpread: 0.002m, // float leg spread over curve rate, often zero
-                stubType: "Front",
+                stubType: "ShortFront",
                 payReceive: "Pay",
                 notionalExchangeType: "None",
                 conventions: flowConventions,
@@ -469,7 +469,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
             // CREATE the leg definitions
             var fixedLegDef = new LegDefinition(
                 rateOrSpread: 0.05m, // fixed leg rate (swap rate)
-                stubType: "Front",
+                stubType: "ShortFront",
                 payReceive: "Pay",
                 notionalExchangeType: "None",
                 conventions: flowConventions
@@ -477,7 +477,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
 
             var floatLegDef = new LegDefinition(
                 rateOrSpread: 0.002m, // float leg spread over curve rate, often zero
-                stubType: "Front",
+                stubType: "ShortFront",
                 payReceive: "Receive",
                 notionalExchangeType: "None",
                 conventions: flowConventions,
@@ -698,7 +698,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
             // CREATE the leg definitions
             var fixedLegDef = new LegDefinition(
                 rateOrSpread: fixedRate, // fixed leg rate (swap rate)
-                stubType: "Front",
+                stubType: "ShortFront",
                 payReceive: fixedLegDirection,
                 notionalExchangeType: "None",
                 conventionName: flowConventionName
@@ -706,7 +706,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Instruments
 
             var floatLegDef = new LegDefinition(
                 rateOrSpread: 0,
-                stubType: "Front",
+                stubType: "ShortFront",
                 payReceive: floatingLegDirection,
                 notionalExchangeType: "None",
                 conventionName: flowConventionName,


### PR DESCRIPTION
…nt is now mapped to stubType.ShortFront.

# Pull Request Checklist

- [X] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass
- [X] Raised the PR against the `develop` branch

# Description of the PR

We are updating the stub types internally since we had duplicates. We have new stub types added and the previous StubType.Front is now mapped to StubType.ShortFront. The new stub types are: None, ShortFront, ShortBack, LongFront, LongBack. 