### PR TITLE
invalid tokens now get new tokens, error messages result in 5 retries…

### DIFF
--- a/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
+++ b/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
@@ -125,8 +125,11 @@ namespace Lusid.Sdk.Tests
             // WHEN we pretend to delay until both...
             // (1) the original token has expired (for expediency update the expires_on on the token)
             provider.ExpireToken();
+            provider.ExpireRefreshToken();
             // (2) the refresh token has expired (for expediency update the refresh_token to an invalid value that will not be found)
+            var oldToken = provider.GetLastToken().Token;
             provider.GetLastToken().RefreshToken = "InvalidRefreshToken";
+            provider.GetLastToken().Token = "invalidToken";
 
             Assert.That(DateTimeOffset.UtcNow, Is.GreaterThan(firstTokenDetails.ExpiresOn));
             var refreshedToken = await provider.GetAuthenticationTokenAsync();
@@ -134,8 +137,8 @@ namespace Lusid.Sdk.Tests
             // THEN it should be populated, and the ExpiresOn should be in the future
             Assert.That(refreshedToken, Is.Not.Empty);
             Assert.That(provider.GetLastToken().ExpiresOn, Is.GreaterThan(DateTimeOffset.UtcNow));
+            Assert.That(oldToken != provider.GetLastToken().Token);
         }
-
     }
 }
 

--- a/sdk/Lusid.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
+++ b/sdk/Lusid.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
@@ -104,7 +104,7 @@ namespace Lusid.Sdk.Utilities
 
         private void OnRetry(Exception arg1, TimeSpan arg2)
         {
-            if (arg1.Message.Contains(ExpireMessage))
+            if (arg1.Message.ToLower().Contains(ExpireMessage))
             {
                 ExpireRefreshToken();
             }


### PR DESCRIPTION
…. New test actually tests this

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Using Polly, the code now retries getting the token upon a failure. If the refresh token has expired then a new token is requested. The test for this now reflects an expired token. Code has been slightly refactored so that it works and reads better.
