### PR TITLE
WEAL-2026: Fixup null reference exception when problem details does not contain request id

### DIFF
--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -141,6 +141,17 @@ namespace Lusid.Sdk.Tests
         }
         
         [Test]
+        public void ApiException_WhenExceptionDoesNotContainRequestId_DoesNotThrow()
+        {
+            var exception = new ApiException(
+                errorCode: 123,
+                message: "Some Critical Exception",
+                errorContent: JsonConvert.SerializeObject(new LusidProblemDetails(name: "CriticalException")));
+
+            Assert.That(exception.GetRequestId(), Is.Null);
+        }
+        
+        [Test]
         public void ApiExceptionMalformedInsightsUrl_ReturnsNull_RequestId()
         {
             try

--- a/sdk/Lusid.Sdk/Utilities/ApiExceptionExtensions.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiExceptionExtensions.cs
@@ -73,12 +73,12 @@ namespace Lusid.Sdk.Utilities
         /// </summary>
         public static string GetRequestId(this ApiException ex)
         {
-            if (ex.ProblemDetails() == null) return null;
-
             // Extract requestId from Insights link contained in the Instance property
-            var instanceParts = ex.ProblemDetails().Instance.Split("/".ToCharArray());
+            var instanceParts = ex?.ProblemDetails()?.Instance?.Split("/".ToCharArray());
 
-            return instanceParts.Length < 7 ? null : instanceParts[6];
+            if (instanceParts == null || instanceParts.Length < 7) return null;
+            
+            return instanceParts[6];
         }
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Caused issues when 500s do not contain request ids