### PR TITLE
IAM-516: Replaced cached configurations with a singleton instance of TokenProviderConfiguration

### DIFF
--- a/sdk/Lusid.Sdk/Client/Configuration.cs
+++ b/sdk/Lusid.Sdk/Client/Configuration.cs
@@ -18,6 +18,7 @@ using System.Net;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Lusid.Sdk.Utilities;
 
 namespace Lusid.Sdk.Client
 {
@@ -494,21 +495,21 @@ namespace Lusid.Sdk.Client
             foreach (var kvp in second.ApiKeyPrefix) apiKeyPrefix[kvp.Key] = kvp.Value;
             foreach (var kvp in second.DefaultHeaders) defaultHeaders[kvp.Key] = kvp.Value;
 
-            var config = new Configuration
-            {
-                ApiKey = apiKey,
-                ApiKeyPrefix = apiKeyPrefix,
-                DefaultHeaders = defaultHeaders,
-                BasePath = second.BasePath ?? first.BasePath,
-                Timeout = second.Timeout,
-                Proxy = second.Proxy ?? first.Proxy,
-                UserAgent = second.UserAgent ?? first.UserAgent,
-                Username = second.Username ?? first.Username,
-                Password = second.Password ?? first.Password,
-                AccessToken = second.AccessToken ?? first.AccessToken,
-                TempFolderPath = second.TempFolderPath ?? first.TempFolderPath,
-                DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat
-            };
+            var config = TokenProviderConfiguration.Instance;
+
+            config.ApiKey = apiKey;
+            config.ApiKeyPrefix = apiKeyPrefix;
+            config.DefaultHeaders = defaultHeaders;
+            config.BasePath = second.BasePath ?? first.BasePath;
+            config.Timeout = second.Timeout;
+            config.Proxy = second.Proxy ?? first.Proxy;
+            config.UserAgent = second.UserAgent ?? first.UserAgent;
+            config.Username = second.Username ?? first.Username;
+            config.Password = second.Password ?? first.Password;
+            //config.AccessToken = second.AccessToken ?? first.AccessToken;
+            config.TempFolderPath = second.TempFolderPath ?? first.TempFolderPath;
+            config.DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat;
+            
             return config;
         }
         #endregion Static Members

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
@@ -46,10 +46,13 @@ namespace Lusid.Sdk.Utilities
 
             // Create configuration
             var tokenProvider = new ClientCredentialsFlowTokenProvider(apiConfiguration);
-            var configuration = new TokenProviderConfiguration(tokenProvider)
-            {
-                BasePath = apiConfiguration.ApiUrl,
-            };
+
+            // We need to set the token provider before accessing TokenProviderConfiguration
+            TokenProviderConfiguration.TokenProvider = tokenProvider;
+            
+            var configuration = TokenProviderConfiguration.Instance;
+            configuration.BasePath = apiConfiguration.ApiUrl;
+            
             
             configuration.DefaultHeaders.Add("X-LUSID-Application", apiConfiguration.ApplicationName);
 

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactoryBuilder.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactoryBuilder.cs
@@ -22,10 +22,12 @@ namespace Lusid.Sdk.Utilities
             // TokenProviderConfiguration.ApiClient is the client used by LusidApiFactory and is 
             // NOT thread-safe, so there needs to be a separate instance for each instance of LusidApiFactory.
             // Do NOT cache the LusidApiFactory instances (DEV-6922)
-            var config = new TokenProviderConfiguration(tokenProvider)
-            {
-                BasePath = url
-            };
+
+            // We need to set the token provider before accessing TokenProviderConfiguration
+            TokenProviderConfiguration.TokenProvider = tokenProvider;
+            
+            var config = TokenProviderConfiguration.Instance;
+            config.BasePath = url;
 
             return new LusidApiFactory(config);
         }

--- a/sdk/Lusid.Sdk/Utilities/TokenProviderConfiguration.cs
+++ b/sdk/Lusid.Sdk/Utilities/TokenProviderConfiguration.cs
@@ -8,22 +8,33 @@ namespace Lusid.Sdk.Utilities
     /// </summary>
     internal class TokenProviderConfiguration : Configuration
     {
-        private readonly ITokenProvider _tokenProvider;
+        private static readonly Lazy<TokenProviderConfiguration> LazyInstance =
+            new Lazy<TokenProviderConfiguration>(() => new TokenProviderConfiguration());
+
+        public static ITokenProvider TokenProvider { private get; set; }
 
         /// <summary>
         /// Create a new Configuration using the supplied token provider
         /// </summary>
-        public TokenProviderConfiguration(ITokenProvider tokenProvider)
+        private TokenProviderConfiguration()
         {
-            _tokenProvider = tokenProvider;
+            if (TokenProvider == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(TokenProvider),
+                    $"Token provider must be set before accessing the {nameof(TokenProviderConfiguration)} instance.");
+            }
         }
+
+        public static TokenProviderConfiguration Instance => LazyInstance.Value;
+
 
         /// <summary>
         /// Gets/sets the accesstoken
         /// </summary>
         public override string AccessToken
         {
-            get => _tokenProvider.GetAuthenticationTokenAsync().Result;
+            get => TokenProvider.GetAuthenticationTokenAsync().Result;
             set => throw new InvalidOperationException("AccessToken is not assignable");
         }
     }


### PR DESCRIPTION
Changed the way that we are feeding the Configuration object to the APIs.

# Pull Request Checklist

- [ ] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

TokenProviderConfiguration is now a singleton and forces one to set its TokenProvider before accessing its instance.

This allows for the same behavior as before: we access the same overriden `AccessToken` property as before which refreshes / retrieves a new token when the old one is expired.

Note that the implementation of the singleton is thread-safe.