### PR TITLE
IAM-516: Fix issue with recreating apis with refreshed access token 

### DIFF
--- a/sdk/Lusid.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
+++ b/sdk/Lusid.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
@@ -57,6 +57,13 @@ namespace Lusid.Sdk.Utilities
 
         
         private AuthenticationToken _lastIssuedToken;
+        
+        /// <summary>
+        /// Checks if current AccessToken if expired
+        /// </summary>
+        public bool IsAccessTokenExpired { 
+            get => _lastIssuedToken == null || _lastIssuedToken.ExpiresOn < DateTimeOffset.UtcNow;
+        }
 
         /// <summary>
         /// Constructor
@@ -82,7 +89,7 @@ namespace Lusid.Sdk.Utilities
                 await _semaphore.WaitAsync();
                 try
                 {
-                    if (_lastIssuedToken == null || _lastIssuedToken.ExpiresOn < DateTimeOffset.UtcNow)
+                    if (IsAccessTokenExpired)
                     {
                         if (_lastIssuedToken?.RefreshToken != null && _lastIssuedToken?.RefreshExpiresOn > DateTimeOffset.UtcNow)
                         {

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
@@ -102,7 +102,7 @@ namespace Lusid.Sdk.Utilities
         public TApi Api<TApi>() where TApi : class, IApiAccessor
         {
 
-            if (_tokenProvider.IsAccessTokenExpired)
+            if (_tokenProvider != null && _tokenProvider.IsAccessTokenExpired)
             {
                 _apis = Init(CreateConfiguration());
             }


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

With a recent update to the sdk, the logic to refresh token broke down since APIs were caching the first created token.

With this change we are now checking on each request if the token is expired - if the token is expired then recreate all apis with a refreshed token
