### PR TITLE
ANA-729: Specify QuoteInterval in rule for ComplexMarketData in preparation for switching on QuoteInterval Filtering

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Instruments/CreditDefaultSwapCashFlow.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Instruments/CreditDefaultSwapCashFlow.cs
@@ -113,14 +113,34 @@ namespace Lusid.Sdk.Tests.tutorials.Instruments
         internal static void CreateAndUpsertRecipe(string code, string scope, ModelSelection.ModelEnum model)
         {
             // CREATE a rule for reset quotes
-            var resetRule = new MarketDataKeyRule("Equity.RIC.*", "Lusid", scope, MarketDataKeyRule.QuoteTypeEnum.Price, "mid", quoteInterval: "1Y");
+            var resetRule = new MarketDataKeyRule(
+                key: "Equity.RIC.*",
+                supplier: "Lusid",
+                scope,
+                MarketDataKeyRule.QuoteTypeEnum.Price,
+                field: "mid",
+                quoteInterval: "1Y");
+            var ratesRule = new MarketDataKeyRule(
+                key: "Rates.*.*",
+                supplier: "Lusid",
+                scope,
+                MarketDataKeyRule.QuoteTypeEnum.Price,
+                field: "mid",
+                quoteInterval: "6Y");
+            var creditRule = new MarketDataKeyRule(
+                key: "Credit.*.*.*.*",
+                supplier: "Lusid",
+                scope,
+                MarketDataKeyRule.QuoteTypeEnum.Spread,
+                field: "mid",
+                quoteInterval: "10Y");
             
             // CREATE recipe for pricing
             var pricingOptions = new PricingOptions(new ModelSelection(ModelSelection.LibraryEnum.Lusid, model));
             var recipe = new ConfigurationRecipe(
                 scope,
                 code,
-                market: new MarketContext(new List<MarketDataKeyRule>{resetRule}, options: new MarketOptions(defaultScope: scope)),
+                market: new MarketContext(new List<MarketDataKeyRule>{resetRule, ratesRule, creditRule}, options: new MarketOptions(defaultScope: scope)),
                 pricing: new PricingContext(options: pricingOptions),
                 description: $"Recipe for {model} pricing");
             

--- a/sdk/Lusid.Sdk.Tests/tutorials/Instruments/CreditDefaultSwapCashFlow.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Instruments/CreditDefaultSwapCashFlow.cs
@@ -113,34 +113,14 @@ namespace Lusid.Sdk.Tests.tutorials.Instruments
         internal static void CreateAndUpsertRecipe(string code, string scope, ModelSelection.ModelEnum model)
         {
             // CREATE a rule for reset quotes
-            var resetRule = new MarketDataKeyRule(
-                key: "Equity.RIC.*",
-                supplier: "Lusid",
-                scope,
-                MarketDataKeyRule.QuoteTypeEnum.Price,
-                field: "mid",
-                quoteInterval: "1Y");
-            var ratesRule = new MarketDataKeyRule(
-                key: "Rates.*.*",
-                supplier: "Lusid",
-                scope,
-                MarketDataKeyRule.QuoteTypeEnum.Price,
-                field: "mid",
-                quoteInterval: "6Y");
-            var creditRule = new MarketDataKeyRule(
-                key: "Credit.*.*.*.*",
-                supplier: "Lusid",
-                scope,
-                MarketDataKeyRule.QuoteTypeEnum.Spread,
-                field: "mid",
-                quoteInterval: "10Y");
+            var resetRule = new MarketDataKeyRule("Equity.RIC.*", "Lusid", scope, MarketDataKeyRule.QuoteTypeEnum.Price, "mid", quoteInterval: "1Y");
             
             // CREATE recipe for pricing
             var pricingOptions = new PricingOptions(new ModelSelection(ModelSelection.LibraryEnum.Lusid, model));
             var recipe = new ConfigurationRecipe(
                 scope,
                 code,
-                market: new MarketContext(new List<MarketDataKeyRule>{resetRule, ratesRule, creditRule}, options: new MarketOptions(defaultScope: scope)),
+                market: new MarketContext(new List<MarketDataKeyRule>{resetRule}, options: new MarketOptions(defaultScope: scope)),
                 pricing: new PricingContext(options: pricingOptions),
                 description: $"Recipe for {model} pricing");
             

--- a/sdk/Lusid.Sdk.Tests/tutorials/Instruments/CreditDefaultSwapCashFlow.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Instruments/CreditDefaultSwapCashFlow.cs
@@ -120,13 +120,15 @@ namespace Lusid.Sdk.Tests.tutorials.Instruments
                 MarketDataKeyRule.QuoteTypeEnum.Price,
                 field: "mid",
                 quoteInterval: "1Y");
+            // CREATE rules for cashflow tests.
+            // We use long quote intervals here because we are happy to use old market data, as pricing is not a concern.
             var ratesRule = new MarketDataKeyRule(
                 key: "Rates.*.*",
                 supplier: "Lusid",
                 scope,
                 MarketDataKeyRule.QuoteTypeEnum.Price,
                 field: "mid",
-                quoteInterval: "6Y");
+                quoteInterval: "10Y");
             var creditRule = new MarketDataKeyRule(
                 key: "Credit.*.*.*.*",
                 supplier: "Lusid",


### PR DESCRIPTION
…mplexMarketDataAccessor.

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

ANA-729 will turn on functionality to filter ComplexMarketData based on the quoteInterval provided in MarketDataKeyRules given in the ConfigurationRecipe (see [this MR](https://gitlab.finbourne.com/finbourne/lusid/lusid-ibor/-/merge_requests/9054). Currently, quoteInterval does nothing in the complexMarketDataAccessor in Lusid, so we can safely change it on rules used for ComplexMarketData without making a functional change. This allows us to preemtively fix the tests that will break by turning on the filtering. This MR fixes the tests that will break in the C# SDK.