### PR TITLE
SENG-54: Change where any internal SDK errors are not bubbled up

### DIFF
--- a/sdk/Lusid.Sdk.Tests/ApiClientTests.cs
+++ b/sdk/Lusid.Sdk.Tests/ApiClientTests.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Lusid.Sdk.Client;
+using Lusid.Sdk.Model;
+using Lusid.Sdk.Tests.Utilities;
+using Lusid.Sdk.Utilities;
+using Moq;
+using NUnit.Framework;
+using RestSharp;
+
+namespace Lusid.Sdk.Tests
+{
+    [TestFixture]
+    public class ApiClientTests
+    {
+        private ILusidApiFactory _apiFactory;
+        private ApiClient _apiClient;
+        private CustomJsonCodec _customJsonCodec;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _apiFactory = TestLusidApiFactoryBuilder.CreateApiFactory("secrets.json");
+            _apiClient = new ApiClient();
+            _customJsonCodec = new CustomJsonCodec(_apiClient.SerializerSettings, GlobalConfiguration.Instance);
+        }
+
+        [Test]
+        [TestCase(" ", "API Response Content was invalid: ' '")]
+        [TestCase("", "API Response Content was invalid: ''")]
+        [TestCase(null, "API Response Content was invalid: ''")]
+        public void TestDeserialize_RestResponseIsNullOrEmpty_ThrowsError(string apiResponseString,
+            string expectedError)
+        {
+            var mockRestResponse = new RestResponse
+            {
+                Content = apiResponseString
+            };
+
+            var exception = Assert.Throws(Is.InstanceOf<Exception>(),
+                () => _customJsonCodec.Deserialize(mockRestResponse, typeof(Portfolio))
+            );
+
+            Assert.That(exception.InnerException.Message, Is.Not.EqualTo(""));
+            Assert.That(exception.InnerException.Message, Is.Not.EqualTo(" "));
+            Assert.That(exception.InnerException.Message, Is.EqualTo(expectedError));
+        }
+
+
+        [Test]
+        [TestCase("some faulty response",
+            "Unexpected character encountered while parsing value: s. Path '', line 0, position 0.")]
+        [TestCase("{\"not-serializable\":\"object\"}",
+            "Required property 'type' not found in JSON. Path '', line 1, position 29.")]
+        public void TestDeserialize_RestResponseIsNotSerializable_ThrowsError(string apiResponseString,
+            string expectedError)
+        {
+            var mockRestResponse = new RestResponse
+            {
+                Content = apiResponseString
+            };
+
+            var exception = Assert.Throws(Is.InstanceOf<Exception>(),
+                () => _customJsonCodec.Deserialize(mockRestResponse, typeof(Portfolio))
+            );
+
+            Assert.That(exception.Message, Is.Not.EqualTo(""));
+            Assert.That(exception.Message, Is.Not.EqualTo(" "));
+            Assert.That(exception.Message, Is.EqualTo(expectedError));
+        }
+
+        [Test]
+        public void CallDefaultExceptionFactory_FailsWithInternalError_Returns500Exception()
+        {
+            var mockException = new Mock<Exception>();
+            const string stackTraceOfError = "Test stack trace";
+            mockException.Setup(e => e.StackTrace).Returns(stackTraceOfError);
+            
+            const string methodName = "someMethod";
+            const string errorText = "some error text";
+            var response = new ApiResponse<Portfolio>(
+                HttpStatusCode.NoContent,
+                new Multimap<string, string>(),
+                null,
+                "Some internal error",
+                ResponseStatus.Error,
+                mockException.Object)
+            {
+                ErrorText = errorText
+            };
+            
+            var returnedError = (ApiException) Configuration.DefaultExceptionFactory.Invoke(methodName, response);
+
+            Assert.That(returnedError.Message, Is.EqualTo($"Internal SDK error occured when calling {methodName}: {errorText}"));
+            Assert.That(returnedError.ErrorCode, Is.EqualTo(500));
+            Assert.That(returnedError.ErrorContent, Is.EqualTo(stackTraceOfError));
+        }
+        
+        [Test]
+        public void CallDefaultExceptionFactory_FailsWithApiError_TheSameErrorCodeNoStackTrace()
+        {
+            const string rawContent = "Not found portfolio";
+            const string methodName = "someMethod";
+            var expectedErrorContent= $"Error calling someMethod: {rawContent}";
+            var response = new ApiResponse<Portfolio>(
+                HttpStatusCode.NotFound,
+                new Multimap<string, string>(),
+                null,
+                rawContent,
+                ResponseStatus.None);
+            
+            var returnedError = (ApiException) Configuration.DefaultExceptionFactory.Invoke(methodName, response);
+
+            Assert.That(returnedError.Message, Is.EqualTo(expectedErrorContent));
+            Assert.That(returnedError.ErrorCode, Is.EqualTo(404));
+            Assert.That(returnedError.ErrorContent, Is.EqualTo(rawContent));
+        }
+    }
+}

--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -12,6 +12,7 @@ using Lusid.Sdk.Utilities;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using System.Net;
+using RestSharp;
 
 namespace Lusid.Sdk.Tests
 {
@@ -389,7 +390,8 @@ namespace Lusid.Sdk.Tests
                 {
                     {"Date", "Tue, 09 Feb 2021 05:18:41 GMT"},
                 },
-                data: new VersionSummaryDto()
+                data: new VersionSummaryDto(),
+                responseStatus: ResponseStatus.None
             );
             var date = apiResponse.GetRequestDateTime();
             Assert.That(date, Is.EqualTo(new DateTimeOffset(2021, 2, 9, 5, 18, 41, new TimeSpan())));

--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Portfolios.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Portfolios.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Lusid.Sdk.Api;
+using Lusid.Sdk.Client;
 using Lusid.Sdk.Model;
 using Lusid.Sdk.Tests.Utilities;
 using Lusid.Sdk.Utilities;
@@ -253,6 +254,7 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
         
         [LusidFeature("F2-4")]
         [Test]
+        // TODO: These tests names need to be renamed and be in line with the standard https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
         public void List_Portfolios()
         {
             //    This defines the scope that the portfolios will be retrieved from
@@ -282,6 +284,16 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
             var scopes = _apiFactory.Api<IScopesApi>().ListScopes();
 
             Assert.That(scopes.Values.Count(), Is.GreaterThan(0));
+        }
+        
+        [Test]
+        public void GetPortfolio_WhenPortfolioNotFound_Throws404Error()
+        {
+            var ex = Assert.Throws<ApiException>(
+                () => _apiFactory.Api<IPortfoliosApi>().GetPortfolio("some-non-existent-scope", "ThisPortfolioDoesntExist")
+            );
+
+            Assert.That(ex.ErrorCode, Is.EqualTo(404));
         }
 
     }

--- a/sdk/Lusid.Sdk/Client/ApiClient.cs
+++ b/sdk/Lusid.Sdk/Client/ApiClient.cs
@@ -137,14 +137,16 @@ namespace Lusid.Sdk.Client
             }
 
             // at this point, it must be a model (json)
-            try
-            {
-                return JsonConvert.DeserializeObject(response.Content, type, _serializerSettings);
-            }
-            catch (Exception e)
-            {
-                throw new ApiException(500, e.Message);
-            }
+            // try
+            // {
+            //     return JsonConvert.DeserializeObject(response.Content, type, _serializerSettings);
+            // }
+            // catch (Exception e)
+            // {
+            //     throw new ApiException(500, e.Message);
+            // }
+            throw new ApiException(500, "Why does this not bubble up an exception, but rather returns an null response?");
+            
         }
 
         public string RootElement { get; set; }

--- a/sdk/Lusid.Sdk/Client/ApiResponse.cs
+++ b/sdk/Lusid.Sdk/Client/ApiResponse.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using RestSharp;
 
 namespace Lusid.Sdk.Client
 {
@@ -24,6 +25,7 @@ namespace Lusid.Sdk.Client
         /// The data type of <see cref="Content"/>
         /// </summary>
         Type ResponseType { get; }
+        
 
         /// <summary>
         /// The content of this response
@@ -56,6 +58,16 @@ namespace Lusid.Sdk.Client
         /// The raw content of this response
         /// </summary>
         string RawContent { get; }
+        
+        /// <summary>
+        /// Status of the response. Indicates whether any internal errors have been thrown.
+        /// </summary>
+        ResponseStatus ResponseStatus { get; }
+        
+        /// <summary>
+        /// Potential internal exception that might occur with the processing of the API call
+        /// </summary>
+        Exception InternalException { get; }
     }
 
     /// <summary>
@@ -108,6 +120,16 @@ namespace Lusid.Sdk.Client
         {
             get { return Data; }
         }
+        
+        /// <summary>
+        /// Status of the response. Indicates whether any internal errors have been thrown.
+        /// </summary>
+        public ResponseStatus ResponseStatus { get; }
+        
+        /// <summary>
+        /// Potential internal exception that might occur with the processing of the API call
+        /// </summary>
+        public Exception InternalException { get; }
 
         /// <summary>
         /// The raw content
@@ -125,8 +147,16 @@ namespace Lusid.Sdk.Client
         /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
         /// <param name="rawContent">Raw content.</param>
-        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, string rawContent)
+        public ApiResponse(
+            HttpStatusCode statusCode, 
+            Multimap<string, string> headers, 
+            T data, 
+            string rawContent, 
+            ResponseStatus responseStatus,
+            Exception ex=null)
         {
+            ResponseStatus = responseStatus;
+            InternalException = ex;
             StatusCode = statusCode;
             Headers = headers;
             Data = data;
@@ -139,7 +169,13 @@ namespace Lusid.Sdk.Client
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data) : this(statusCode, headers, data, null)
+        public ApiResponse(
+            HttpStatusCode statusCode, 
+            Multimap<string, string> headers, 
+            T data, 
+            ResponseStatus responseStatus, 
+            Exception ex=null) 
+            : this(statusCode, headers, data, null, responseStatus, ex)
         {
         }
 
@@ -149,7 +185,13 @@ namespace Lusid.Sdk.Client
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
         /// <param name="rawContent">Raw content.</param>
-        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent) : this(statusCode, null, data, rawContent)
+        public ApiResponse(
+            HttpStatusCode statusCode, 
+            T data, 
+            string rawContent, 
+            ResponseStatus responseStatus, 
+            Exception ex=null) 
+            : this(statusCode, null, data, rawContent, responseStatus, ex)
         {
         }
 
@@ -158,7 +200,12 @@ namespace Lusid.Sdk.Client
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, T data) : this(statusCode, data, null)
+        public ApiResponse(
+            HttpStatusCode statusCode, 
+            T data, 
+            ResponseStatus responseStatus, 
+            Exception ex=null) 
+            : this(statusCode, data, null, responseStatus, ex)
         {
         }
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Main changes:
- Some basic code clean up to make the code with lots of text more readable
- Instantiated RestClient with FailOnDeserializationError = true so that we could later handle internal SDK errors
- Added a new check in the ExceptionFactory, so that if we get a 200 status code response, but the processing was a failure, we throw an API exception
- The API response no longer returns null on failure, but instead throws a 500 with the stack trace where the failure happened in the code. 

Related to https://finbourne.atlassian.net/browse/SENG-54
