### PR TITLE
PLAT-784: SDK should throw exceptions on network connectivity issues

### DIFF
--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -439,5 +439,12 @@ namespace Lusid.Sdk.Tests
             var date = apiResponse.GetRequestDateTime();
             Assert.IsNull(date);
         }
+
+        [Test]
+        public void ExceptionFactoryIsOverriddenWithCustomImplementation()
+        {
+            var api = _factory.Api<ApplicationMetadataApi>();
+            Assert.That(api.ExceptionFactory.GetInvocationList().Single().Method.Name, Is.EqualTo(nameof(LusidExceptionHandler.CustomExceptionFactory)));
+        }
     }
 }

--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -107,7 +107,29 @@ namespace Lusid.Sdk.Tests
                 () => new LusidApiFactory(apiConfig),
                 Throws.InstanceOf<UriFormatException>().With.Message.EqualTo("Invalid LUSID Uri: xyz"));
         }
-        
+
+        [Test]
+        public void NetworkConnectivityErrors_ThrowsException()
+        {
+            var apiConfig = ApiConfigurationBuilder.Build("secrets.json");
+            apiConfig.ApiUrl = "https://localhost:56789/api"; // nothing should be listening on this, so we should get a "No connection could be made" error...
+
+            var factory = new LusidApiFactory(apiConfig);
+            var api = factory.Api<PortfoliosApi>();
+            
+            Assert.That(
+                () => api.GetPortfolioWithHttpInfo("someScope", "someCode"),
+                Throws.InstanceOf<ApiException>()
+                    .With.Message.Contains("Error calling GetPortfolio: No connection could be made"));
+
+            // Note: these non-"WithHttpInfo" methods just unwrap the `Data` property from the call above.
+            // But these were the problematic ones, as they would previously just return a null value in this scenario.
+            Assert.That(
+                () => api.GetPortfolio("someScope", "someCode"),
+                Throws.InstanceOf<ApiException>()
+                    .With.Message.Contains("Error calling GetPortfolio")); // can't be more specific: get different exceptions locally vs in the build pipeline
+        }
+
         [Test]
         public void ApiResponse_CanExtract_RequestId()
         {

--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -116,18 +116,21 @@ namespace Lusid.Sdk.Tests
 
             var factory = new LusidApiFactory(apiConfig);
             var api = factory.Api<PortfoliosApi>();
+
+            // Can't be more specific as we get different exceptions locally vs in the build pipeline
+            var expectedMsg = "Internal SDK error occurred when calling GetPortfolio";
             
             Assert.That(
                 () => api.GetPortfolioWithHttpInfo("someScope", "someCode"),
                 Throws.InstanceOf<ApiException>()
-                    .With.Message.Contains("Error calling GetPortfolio: No connection could be made"));
+                    .With.Message.Contains(expectedMsg));
 
             // Note: these non-"WithHttpInfo" methods just unwrap the `Data` property from the call above.
             // But these were the problematic ones, as they would previously just return a null value in this scenario.
             Assert.That(
                 () => api.GetPortfolio("someScope", "someCode"),
                 Throws.InstanceOf<ApiException>()
-                    .With.Message.Contains("Error calling GetPortfolio")); // can't be more specific: get different exceptions locally vs in the build pipeline
+                    .With.Message.Contains(expectedMsg)); 
         }
 
         [Test]

--- a/sdk/Lusid.Sdk.Tests/LusidExceptionHandlerTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidExceptionHandlerTests.cs
@@ -1,0 +1,111 @@
+﻿using System.Net;
+using Lusid.Sdk.Api;
+using Lusid.Sdk.Client;
+using Lusid.Sdk.Model;
+using Lusid.Sdk.Tests.Utilities;
+using Lusid.Sdk.Utilities;
+using NUnit.Framework;
+
+namespace Lusid.Sdk.Tests
+{
+    [TestFixture]
+    public class LusidExceptionHandlerTests
+    {
+        private ILusidApiFactory _apiFactory;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _apiFactory = TestLusidApiFactoryBuilder.CreateApiFactory("secrets.json");
+        }
+
+        [Test]
+        public void CallCustomExceptionFactory_FailsWithInternalError_ReturnsErrorAsException()
+        {
+            const string methodName = "someMethod";
+            const string errorText = "some error text";
+            var response = new ApiResponse<Portfolio>(
+                HttpStatusCode.OK,
+                new Multimap<string, string>(),
+                null,
+                "Some internal error")
+            {
+                ErrorText = errorText
+            };
+
+            var returnedError = (ApiException)LusidExceptionHandler.CustomExceptionFactory(methodName, response);
+
+            Assert.That(returnedError.Message, Is.EqualTo($"Internal SDK error occurred when calling {methodName}: {errorText}"));
+            Assert.That(returnedError.ErrorCode, Is.EqualTo(200));
+            Assert.That(returnedError.ErrorContent, Is.EqualTo(errorText));
+        }
+
+        [Test]
+        public void CallCustomExceptionFactory_FailsWithApiError_ReturnsTheSameErrorCodeAsApi()
+        {
+            const string rawContent = "Not found portfolio";
+            const string methodName = "someMethod";
+            var expectedErrorContent = $"Error calling someMethod: {rawContent}";
+            var response = new ApiResponse<Portfolio>(
+                HttpStatusCode.NotFound,
+                new Multimap<string, string>(),
+                null,
+                rawContent);
+
+            var returnedError = (ApiException)LusidExceptionHandler.CustomExceptionFactory(methodName, response);
+
+            Assert.That(returnedError.Message, Is.EqualTo(expectedErrorContent));
+            Assert.That(returnedError.ErrorCode, Is.EqualTo(404));
+            Assert.That(returnedError.ErrorContent, Is.EqualTo(rawContent));
+        }
+
+        [Test]
+        public void CallPortfoliosApiExceptionFactory_DefaultIsOverriden_ExceptionFactoryOfApiIsSameAsCustomOne()
+        {
+            const string methodName = "someMethod";
+            const string errorText = "some error text";
+            var response = new ApiResponse<Portfolio>(
+                default,
+                new Multimap<string, string>(),
+                null,
+                "Some internal error")
+            {
+                ErrorText = errorText
+            };
+
+            var customExceptionHandlerError = (ApiException)LusidExceptionHandler.CustomExceptionFactory(methodName, response);
+            var errorOnTheApi = (ApiException)_apiFactory.Api<IPortfoliosApi>().ExceptionFactory.Invoke(methodName, response);
+
+            // Assert that the error has correct values
+            Assert.That(customExceptionHandlerError.Message, Is.EqualTo($"Internal SDK error occurred when calling {methodName}: {errorText}"));
+            Assert.That(customExceptionHandlerError.ErrorCode, Is.EqualTo(0));
+            Assert.That(customExceptionHandlerError.ErrorContent, Is.EqualTo(errorText));
+
+            // Assert that the custom exception handler errors are the same as the errors on the API
+            Assert.That(customExceptionHandlerError.Message, Is.EqualTo(errorOnTheApi.Message));
+            Assert.That(customExceptionHandlerError.ErrorCode, Is.EqualTo(errorOnTheApi.ErrorCode));
+            Assert.That(customExceptionHandlerError.ErrorContent, Is.EqualTo(errorOnTheApi.ErrorContent));
+        }
+
+        [Test]
+        public void CallDefaultExceptionFactory_ItIsDifferentThanOnApi_DefaultExceptionFactoryResponseIsNullAndApiOneIsNot()
+        {
+            const string methodName = "someMethod";
+            const string errorText = "some error text";
+            var response = new ApiResponse<Portfolio>(
+                HttpStatusCode.NoContent,
+                new Multimap<string, string>(),
+                null,
+                "Some internal error")
+            {
+                ErrorText = errorText,
+            };
+
+            var defaultExceptionFactoryError = (ApiException)Configuration.DefaultExceptionFactory.Invoke(methodName, response);
+            var errorOnTheApi = (ApiException)_apiFactory.Api<IPortfoliosApi>().ExceptionFactory.Invoke(methodName, response);
+
+            Assert.That(defaultExceptionFactoryError, Is.Null);
+            Assert.That(errorOnTheApi, Is.Not.Null);
+        }
+    }
+}

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
@@ -76,6 +76,9 @@ namespace Lusid.Sdk.Utilities
                     throw new Exception($"Unable to create type {api}");
                 }
 
+                // Replace the default implementation of the ExceptionFactory with a custom one defined by FINBOURNE
+                impl.ExceptionFactory = LusidExceptionHandler.CustomExceptionFactory;
+
                 var @interface = api.GetInterfaces()
                     .First(i => typeof(IApiAccessor).IsAssignableFrom(i));
 

--- a/sdk/Lusid.Sdk/Utilities/LusidExceptionHandler.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidExceptionHandler.cs
@@ -1,0 +1,42 @@
+using System;
+using Lusid.Sdk.Client;
+
+namespace Lusid.Sdk.Utilities
+{
+    /// <summary>
+    /// Handles the generation of LUSID exceptions after receiving the ApiResponse
+    /// </summary>
+    internal static class LusidExceptionHandler
+    {
+        /// <summary>
+        /// Generate exceptions from the ApiResponse when ResponseStatus is an Error,
+        /// and StatusCode has no content or is less than 400
+        /// </summary>
+        /// <param name="methodName">The name of the method that was being called</param>
+        /// <param name="response">The ApiResponse</param>
+        public static Exception CustomExceptionFactory(string methodName, IApiResponse response)
+        {
+            // Use default exception handler first (only use subsequent checks if this returns null)
+            Exception defaultException = Configuration.DefaultExceptionFactory.Invoke(methodName, response);
+            if (defaultException != null)
+            {
+                return defaultException;
+            }
+
+            // Throw if ErrorText has been populated:
+            //  - Internal SDK deserialization errors will result in ErrorText to be not null.
+            //  - Network-level errors will also result in ErrorText being populated.
+            if (response.ErrorText != null)
+            {
+                return new ApiException(
+                    (int) response.StatusCode,
+                    $"Internal SDK error occurred when calling {methodName}: {response.ErrorText}",
+                    response.ErrorText,
+                    response.Headers
+                );
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR
Under some circumstances we see SDK method calls returning null response values, which inevitably causes expected NullReferenceExceptions in calling code.

This PR makes the SDK throw an exception if the request fails to call the API at all (e.g. due to a network connectivity problem: bad URL / port etc), whereas it would previously return a null response.