### PR TITLE
ANA-1214: rename Equity to Quote in  MarketDataRule keys

### DIFF
--- a/sdk/Lusid.Sdk.Tests/Utilities/TestDataUtilities.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/TestDataUtilities.cs
@@ -556,7 +556,7 @@ namespace Lusid.Sdk.Tests.Utilities
             // For simpleStaticRule, note that inside CreatePortfolioAndInstrument, the method TestDataUtilities.BuildInstrumentUpsertRequest books the instrument using "ClientInternal".
             // As such the quote upserted using "ClientInternal". The market rule key needs to be "ClientInternal" also to find the quote.  
             var simpleStaticRule = new MarketDataKeyRule(
-                key: "Equity.ClientInternal.*",
+                key: "Quote.ClientInternal.*",
                 supplier: "Lusid",
                 scope,
                 MarketDataKeyRule.QuoteTypeEnum.Price,
@@ -564,7 +564,7 @@ namespace Lusid.Sdk.Tests.Utilities
                 quoteInterval: "1M");
             
             var figiRule = new MarketDataKeyRule(
-                key: "Equity.Figi.*",
+                key: "Quote.Figi.*",
                 supplier: "Lusid",
                 scope,
                 MarketDataKeyRule.QuoteTypeEnum.Price,
@@ -573,7 +573,7 @@ namespace Lusid.Sdk.Tests.Utilities
             
             // resetRule is used to locate reset rates such as that for interest rate swaps and swaptions
             var resetRule = new MarketDataKeyRule(
-                key: "Equity.RIC.*",
+                key: "Quote.RIC.*",
                 supplier: "Lusid",
                 scope,
                 MarketDataKeyRule.QuoteTypeEnum.Price,

--- a/sdk/Lusid.Sdk.Tests/Utilities/TutorialBase.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/TutorialBase.cs
@@ -73,7 +73,7 @@ namespace Lusid.Sdk.Utilities
             pricingOptions.WindowValuationOnInstrumentStartEnd = windowValuationOnInstrumentStartEnd;
             
             // DEFINE rules to pick up reset quotes
-            var resetRule = new MarketDataKeyRule("Equity.RIC.*", "Lusid", scope , MarketDataKeyRule.QuoteTypeEnum.Price, "mid", quoteInterval: "1Y");
+            var resetRule = new MarketDataKeyRule("Quote.RIC.*", "Lusid", scope , MarketDataKeyRule.QuoteTypeEnum.Price, "mid", quoteInterval: "1Y");
             
             // CREATE recipe
             var recipe = new ConfigurationRecipe(


### PR DESCRIPTION
# Pull Request Checklist

- [ x ] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ x ] Tests pass
- [ x ] Raised the PR against the `develop` branch

# Description of the PR

Market Data Key Rules allow one to specify where market data should be taken from when . For example, "ask TRKD for quotes", "check in scope 'myScope' for interest rates curves". These rules currently use the word "Equity" to refer to anything that can be looked up in the quotes store, including for example, a historical interest rate. This is confusing as it's not an equity. Now, we support the word "Quote" as an alias for "Equity", hopefully this new name is less confusing.
