### PR TITLE
ANA-1476: Overriding of accrual no longer happens through UnitResult/Accrued, hence updating examples to reflect the changes.

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/StructuredResultStore.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/StructuredResultStore.cs
@@ -128,7 +128,7 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
                 metrics: new List<AggregateSpec>
                 {
                     new AggregateSpec(TestDataUtilities.Luid, AggregateSpec.OpEnum.Value),
-                    // Obtain InstrumentAccrued from the store. Since we are overriding it this is the same as calling Valuation/Accrued.
+                    // Obtain InstrumentAccrued from the store. Since we are overriding the InstrumentAccrued this is the same as calling Valuation/Accrued.
                     new AggregateSpec("UnitResult/Valuation/InstrumentAccrued", AggregateSpec.OpEnum.Value),
                     new AggregateSpec(TestDataUtilities.ValuationPv, AggregateSpec.OpEnum.Value),
                     new AggregateSpec("UnitResult/ClientCustomValue", AggregateSpec.OpEnum.Value),

--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/StructuredResultStore.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/StructuredResultStore.cs
@@ -128,9 +128,9 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
                 metrics: new List<AggregateSpec>
                 {
                     new AggregateSpec(TestDataUtilities.Luid, AggregateSpec.OpEnum.Value),
+                    // Obtain InstrumentAccrued from the store. Since we are overriding it this is the same as calling Valuation/Accrued.
                     new AggregateSpec("UnitResult/Valuation/InstrumentAccrued", AggregateSpec.OpEnum.Value),
                     new AggregateSpec(TestDataUtilities.ValuationPv, AggregateSpec.OpEnum.Value),
-                    new AggregateSpec("Holding/default/PV", AggregateSpec.OpEnum.Value),
                     new AggregateSpec("UnitResult/ClientCustomValue", AggregateSpec.OpEnum.Value),
                     new AggregateSpec("Valuation/InstrumentAccrued", AggregateSpec.OpEnum.Value),
                 },


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Upcoming changes in lusid will be disabling looking up UnitResult/Accrued in LusidPricingModel which in turn will cause the override to work in a different way than it did before. Clients are aware. This is an update for the notebook to match the lusid changes.
