### PR TITLE
Adds Personal Access Token Provider.

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -6,16 +6,16 @@ name: Build and test
 
 on:
   push:
-    branches: [ develop ]
+    branches: [develop]
   pull_request:
-    branches: [ master, develop ]
+    branches: [master, develop]
 
 jobs:
   # This workflow contains a single job called "build"
   build-and-test:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run tests on DEVELOP branch
         if: ${{ github.base_ref == 'develop' || github.ref == 'refs/heads/develop' }}
-        env: 
+        env:
           FBN_TOKEN_URL: ${{ secrets.DEVELOP_FBN_TOKEN_URL }}
           FBN_USERNAME: ${{ secrets.DEVELOP_FBN_USERNAME }}
           FBN_PASSWORD: ${{ secrets.DEVELOP_FBN_PASSWORD }}
@@ -50,10 +50,10 @@ jobs:
           echo "Running the tests..."
           docker-compose up --abort-on-container-exit
           echo "Tests COMPLETED"
-      
+
       - name: Run tests on MASTER branch
         if: ${{ github.base_ref == 'master' }}
-        env: 
+        env:
           FBN_TOKEN_URL: ${{ secrets.MASTER_FBN_TOKEN_URL }}
           FBN_USERNAME: ${{ secrets.MASTER_FBN_USERNAME }}
           FBN_PASSWORD: ${{ secrets.MASTER_FBN_PASSWORD }}
@@ -62,7 +62,7 @@ jobs:
           FBN_LUSID_API_URL: ${{ secrets.MASTER_FBN_LUSID_API_URL }}
           FBN_APP_NAME: ${{ secrets.MASTER_FBN_CLIENT_ID }}
           FBN_LUSID_ACCESS_TOKEN: ${{ secrets.MASTER_FBN_ACCESS_TOKEN }}
-        run: | 
+        run: |
           echo "env variables for MASTER have been set"
           echo "Changing directory into sdk directory"
           cd sdk          

--- a/.gitignore
+++ b/.gitignore
@@ -539,3 +539,6 @@ Temporary Items
 
 # Environments
 **/.env
+
+# features file
+features.txt

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -9,7 +9,4 @@ COPY Lusid.Sdk/ /usr/src/Lusid.Sdk/
 COPY LusidFeatureReporter/ /usr/src/LusidFeatureReporter/
 COPY Lusid.Sdk.Tests/ /usr/src/Lusid.Sdk.Tests/
 
-
-ENV FBN_LUSID_API_URL ${FBN_LUSID_API_URL}
-
 ENTRYPOINT ["./run.sh"]

--- a/sdk/Lusid.Sdk.Tests/Lusid.Sdk.Tests.csproj
+++ b/sdk/Lusid.Sdk.Tests/Lusid.Sdk.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="LusidFeatures" Version="0.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="secrets.json" CopyToOutputDirectory="Always" Condition="Exists('secrets.json')" />

--- a/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
+++ b/sdk/Lusid.Sdk.Tests/LusidApiFactoryTests.cs
@@ -367,7 +367,7 @@ namespace Lusid.Sdk.Tests
 
         [TestCase(1, 10)]
         [TestCase(100, 25, Explicit = true)]
-        public void Multi_Threaded_ApiFactory_Tasks_WithPACToken(int quoteCount, int threadCount)
+        public void Multi_Threaded_ApiFactory_Tasks_With_PersonalAccessToken(int quoteCount, int threadCount)
         {
             var config = ApiConfigurationBuilder.Build(null);
             if (config.MissingPersonalAccessTokenVariables)

--- a/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
+++ b/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
@@ -19,6 +19,11 @@ namespace Lusid.Sdk.Tests
         [Test]
         public async Task CanGetToken()
         {
+            if (ApiConfig.Value.MissingSecretVariables)
+            {
+                Assert.Inconclusive();
+            }
+
             // GIVEN a token provider initialised with required secrets
             var provider = new ClientCredentialsFlowTokenProvider(ApiConfig.Value);
 
@@ -30,8 +35,31 @@ namespace Lusid.Sdk.Tests
         }
 
         [Test]
+        public async Task CanGetPersonalAccessToken()
+        {
+            if (ApiConfig.Value.MissingPersonalAccessTokenVariables)
+            {
+                Assert.Inconclusive();
+            }
+
+            // GIVEN a token provider initialised with required secrets
+            var provider = new PersonalAccessTokenProvider(ApiConfig.Value.PersonalAccessToken);
+
+            // WHEN the token is requested
+            var token = await provider.GetAuthenticationTokenAsync();
+
+            // THEN it is populated
+            Assert.That(token, Is.Not.Empty);
+        }
+
+        [Test]
         public async Task CanRefreshWithRefreshToken()
         {
+            if (ApiConfig.Value.MissingSecretVariables)
+            {
+                Assert.Inconclusive();
+            }
+            
             // GIVEN a token from the TokenProvider that contains a refresh token
             var provider = new ClientCredentialsFlowTokenProvider(ApiConfig.Value);
             var _ = await provider.GetAuthenticationTokenAsync();
@@ -55,6 +83,11 @@ namespace Lusid.Sdk.Tests
         [Test, Explicit("Needs to have secrets.json file containing user without offline-access enabled")]
         public async Task CanRefreshWithoutToken()
         {
+            if (ApiConfig.Value.MissingSecretVariables)
+            {
+                Assert.Inconclusive();
+            }
+
             // GIVEN a token from the TokenProvider that DOES NOT contain a refresh token
             var provider = new ClientCredentialsFlowTokenProvider(ApiConfig.Value);
             var _ = await provider.GetAuthenticationTokenAsync();
@@ -97,6 +130,11 @@ namespace Lusid.Sdk.Tests
         [Test]
         public void Can_Retrieve_Same_Token_From_Multiple_Threads()
         {
+            if (ApiConfig.Value.MissingSecretVariables)
+            {
+                Assert.Inconclusive();
+            }
+
             const int threadCount = 100;
             
             //    create threads with calls to get a token
@@ -111,8 +149,33 @@ namespace Lusid.Sdk.Tests
         }
         
         [Test]
+        public void Can_Retrieve_Same_PersonalAccessToken_From_Multiple_Threads()
+        {
+            if (ApiConfig.Value.MissingPersonalAccessTokenVariables)
+            {
+                Assert.Inconclusive();
+            }
+
+            const int threadCount = 100;
+
+            //    create threads with calls to get a token
+            var providers = Enumerable.Repeat(new PersonalAccessTokenProvider(ApiConfig.Value.PersonalAccessToken), threadCount).ToList();
+            var requests = providers.Select(p => p.GetAuthenticationTokenAsync());
+
+            //    get the tokens
+            Task.WaitAll(requests.ToArray());
+
+            //    all requests must have the same token i.e. reuse a valid token
+            Assert.That(requests.GroupBy(r => r.Result).Count(), Is.EqualTo(1), "Requests have different tokens");
+        }
+
+        [Test]
         public async Task CanGetNewTokenWhenRefreshTokenExpired()
         {
+            if (ApiConfig.Value.MissingSecretVariables)
+            {
+                Assert.Inconclusive();
+            }
             
             var provider = new ClientCredentialsFlowTokenProvider(ApiConfig.Value);
             var _ = await provider.GetAuthenticationTokenAsync();

--- a/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationBuilderTest.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationBuilderTest.cs
@@ -149,6 +149,7 @@ namespace Lusid.Sdk.Tests.Utilities
             Environment.SetEnvironmentVariable("FBN_USERNAME", "<env.username>");
             Environment.SetEnvironmentVariable("FBN_PASSWORD", "");
             Environment.SetEnvironmentVariable("FBN_APP_NAME", "<env.app_name>");
+            Environment.SetEnvironmentVariable("FBN_ACCESS_TOKEN", "");
 
             var exception = Assert.Throws<MissingConfigException>(() => ApiConfigurationBuilder.Build(null));
             Assert.That(exception.Message,

--- a/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationTests.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationTests.cs
@@ -1,0 +1,41 @@
+using Lusid.Sdk.Utilities;
+using NUnit.Framework;
+
+namespace Lusid.Sdk.Tests.Utilities
+{
+    [TestFixture]
+    public class ApiConfigurationTest
+    {
+        [Test]
+        public void TestHasMissingPatConfig()
+        {
+            var config = new ApiConfiguration() {PersonalAccessToken = "token"};
+            Assert.IsTrue(config.HasMissingConfig());
+            Assert.AreEqual("ApiUrl", string.Join(",", config.GetMissingConfig()));
+        }
+
+        [Test]
+        public void TestHasCompletePatConfig()
+        {
+            var config = new ApiConfiguration() {PersonalAccessToken = "token", ApiUrl = "http://bla.com"};
+            Assert.IsFalse(config.HasMissingConfig());
+            Assert.AreEqual("", string.Join(",", config.GetMissingConfig()));
+        }
+
+        [Test]
+        public void TestHasMissingSecretsConfig()
+        {
+            var config = new ApiConfiguration() {ApiUrl = "http://bla.com"};
+            Assert.IsTrue(config.HasMissingConfig());
+            Assert.AreEqual("TokenUrl,Username,Password,ClientId,ClientSecret", string.Join(",", config.GetMissingConfig()));
+        }
+
+        [Test]
+        public void TestHasCompleteSecretsConfig()
+        {
+            var config = new ApiConfiguration() {ApiUrl = "http://bla.com", Username = "un", Password = "pwd", ClientId = "cid", ClientSecret = "cs", TokenUrl = "tu"};
+            Assert.IsFalse(config.HasMissingConfig());
+            Assert.AreEqual(string.Empty, string.Join(",", config.GetMissingConfig()));
+        }
+    }
+} 

--- a/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationTests.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/ApiConfigurationTests.cs
@@ -7,7 +7,7 @@ namespace Lusid.Sdk.Tests.Utilities
     public class ApiConfigurationTest
     {
         [Test]
-        public void TestHasMissingPatConfig()
+        public void TestHasMissingPersonalAccessTokenConfig()
         {
             var config = new ApiConfiguration() {PersonalAccessToken = "token"};
             Assert.IsTrue(config.HasMissingConfig());
@@ -15,7 +15,7 @@ namespace Lusid.Sdk.Tests.Utilities
         }
 
         [Test]
-        public void TestHasCompletePatConfig()
+        public void TestHasCompletePersonalAccessTokenConfig()
         {
             var config = new ApiConfiguration() {PersonalAccessToken = "token", ApiUrl = "http://bla.com"};
             Assert.IsFalse(config.HasMissingConfig());

--- a/sdk/Lusid.Sdk/Utilities/ApiConfiguration.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiConfiguration.cs
@@ -30,7 +30,7 @@ namespace Lusid.Sdk.Utilities
         /// <summary>
         /// OAuth2 Client Secret
         /// </summary>
-        public string ClientSecret { get;  set; }
+        public string ClientSecret { get; set; }
 
         /// <summary>
         /// LUSID Api Url
@@ -41,52 +41,81 @@ namespace Lusid.Sdk.Utilities
         /// Client Application name
         /// </summary>
         public string ApplicationName { get; set; }
-        
+
+        /// <summary>
+        /// Configurable via FBN_ACCESS_TOKEN env variable - get the value from LUSID web 'Your Profile'->'Personal access tokens'.
+        /// Takes precedence over other authentication factors if set.
+        /// </summary>
+        public string PersonalAccessToken { get; set; }
+
+        internal bool MissingPersonalAccessTokenVariables =>
+            string.IsNullOrEmpty(PersonalAccessToken) ||
+            string.IsNullOrEmpty(ApiUrl);
+
+        internal bool MissingSecretVariables =>
+            string.IsNullOrEmpty(TokenUrl) ||
+            string.IsNullOrEmpty(Username) ||
+            string.IsNullOrEmpty(Password) ||
+            string.IsNullOrEmpty(ClientId) ||
+            string.IsNullOrEmpty(ClientSecret) ||
+            string.IsNullOrEmpty(ApiUrl);
+
         /// <summary>
         /// Checks if any of the required configuration values are missing
         /// </summary>
         /// <returns></returns>
         public bool HasMissingConfig()
         {
-            return string.IsNullOrEmpty(TokenUrl) ||
-                   string.IsNullOrEmpty(Username) ||
-                   string.IsNullOrEmpty(Password) ||
-                   string.IsNullOrEmpty(ClientId) ||
-                   string.IsNullOrEmpty(ClientSecret) ||
-                   string.IsNullOrEmpty(ApiUrl);
+            return MissingPersonalAccessTokenVariables && MissingSecretVariables;
         }
 
         /// <summary>
         /// Returns a list of the missing required configuration values
         /// </summary>
         /// <returns></returns>
-        public List<string> MissingConfig()
+        public List<string> GetMissingConfig()
         {
             var missingConfig = new List<string>();
+
+            if (!string.IsNullOrEmpty(PersonalAccessToken))
+            {
+                if (MissingPersonalAccessTokenVariables)
+                {
+                    missingConfig.Add("ApiUrl");
+                }
+                return missingConfig; // in case PAC is to be used we don't care about the other properties
+            }
+
             if (string.IsNullOrEmpty(TokenUrl))
             {
                 missingConfig.Add("TokenUrl");
             }
+
             if (string.IsNullOrEmpty(Username))
             {
                 missingConfig.Add("Username");
             }
+
             if (string.IsNullOrEmpty(Password))
             {
                 missingConfig.Add("Password");
             }
+
             if (string.IsNullOrEmpty(ClientId))
             {
                 missingConfig.Add("ClientId");
             }
+
             if (string.IsNullOrEmpty(ClientSecret))
             {
                 missingConfig.Add("ClientSecret");
-            } 
+            }
+            
             if (string.IsNullOrEmpty(ApiUrl))
             {
                 missingConfig.Add("ApiUrl");
             }
+            
             return missingConfig;
         }
     }

--- a/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiConfigurationBuilder.cs
@@ -19,6 +19,7 @@ namespace Lusid.Sdk.Utilities
             { "ClientSecret", "FBN_CLIENT_SECRET" },
             { "Username", "FBN_USERNAME" },
             { "Password", "FBN_PASSWORD" },
+            { "PersonalAccessToken", "FBN_ACCESS_TOKEN" },
         };
 
         private static readonly Dictionary<string, string> ConfigNamesToSecrets = new Dictionary<string, string>()
@@ -64,12 +65,14 @@ namespace Lusid.Sdk.Utilities
                 Password = Environment.GetEnvironmentVariable("FBN_PASSWORD") ??
                            Environment.GetEnvironmentVariable("fbn_password"),
                 ApplicationName = Environment.GetEnvironmentVariable("FBN_APP_NAME") ??
-                                  Environment.GetEnvironmentVariable("fbn_app_name")
+                                  Environment.GetEnvironmentVariable("fbn_app_name"),
+                PersonalAccessToken = Environment.GetEnvironmentVariable("FBN_ACCESS_TOKEN") ?? 
+                                Environment.GetEnvironmentVariable("fbn_access_token"),
             };
 
             if (apiConfig.HasMissingConfig())
             {
-                var missingValues = apiConfig.MissingConfig()
+                var missingValues = apiConfig.GetMissingConfig()
                     .Select(value => $"'{ConfigNamesToEnvVariables[value]}'");
                 var message = $"[{string.Join(", ", missingValues)}]";
                 throw new MissingConfigException(
@@ -96,7 +99,7 @@ namespace Lusid.Sdk.Utilities
 
             if (apiConfig.HasMissingConfig())
             {
-                var missingValues = apiConfig.MissingConfig()
+                var missingValues = apiConfig.GetMissingConfig()
                     .Select(value => $"'{ConfigNamesToSecrets[value]}'");
                 var message = $"[{string.Join(", ", missingValues)}]";
                 throw new MissingConfigException(
@@ -123,7 +126,7 @@ namespace Lusid.Sdk.Utilities
 
             if (apiConfig.HasMissingConfig())
             {
-                var missingValues = apiConfig.MissingConfig()
+                var missingValues = apiConfig.GetMissingConfig()
                     .Select(value => $"'{value}'");
                 var message = $"[{string.Join(", ", missingValues)}]";
                 throw new MissingConfigException(

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
@@ -33,19 +33,27 @@ namespace Lusid.Sdk.Utilities
         {
             if (apiConfiguration == null) throw new ArgumentNullException(nameof(apiConfiguration));
 
-            // Validate Uris
-            if (!Uri.TryCreate(apiConfiguration.TokenUrl, UriKind.Absolute, out var _))
-            {
-                throw new UriFormatException($"Invalid Token Uri: {apiConfiguration.TokenUrl}");
-            }
-
             if (!Uri.TryCreate(apiConfiguration.ApiUrl, UriKind.Absolute, out var _))
             {
                 throw new UriFormatException($"Invalid LUSID Uri: {apiConfiguration.ApiUrl}");
             }
 
+            // note: could employ a factory pattern here to create ITokenProvider in case more branching is required in the future:
+            ITokenProvider tokenProvider;
+            if (!string.IsNullOrEmpty(apiConfiguration.PersonalAccessToken)) // the personal access token takes precedence over other methods of authentication
+            {
+                tokenProvider = new PersonalAccessTokenProvider(apiConfiguration.PersonalAccessToken);
+            }
+            else
+            {                
+                if (!Uri.TryCreate(apiConfiguration.TokenUrl, UriKind.Absolute, out var _))
+                {
+                    throw new UriFormatException($"Invalid Token Uri: {apiConfiguration.TokenUrl}");
+                }
+                tokenProvider = new ClientCredentialsFlowTokenProvider(apiConfiguration);    
+            }
+            
             // Create configuration
-            var tokenProvider = new ClientCredentialsFlowTokenProvider(apiConfiguration);
             var configuration = new TokenProviderConfiguration(tokenProvider)
             {
                 BasePath = apiConfiguration.ApiUrl,

--- a/sdk/Lusid.Sdk/Utilities/PersonalAccessTokenProvider.cs
+++ b/sdk/Lusid.Sdk/Utilities/PersonalAccessTokenProvider.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Lusid.Sdk.Utilities
+{
+    /// <summary>
+    /// Provides a PersonalAccessTokenProvider from an environment variable
+    /// </summary>
+    public class PersonalAccessTokenProvider : ITokenProvider
+    {
+        private string _token;
+
+        /// <summary>
+        /// Implementation of a TokenProvider for use with a Personal Access Token - generated in LUSID web and used in a FBN_ACCESS_TOKEN env variable.
+        /// </summary>
+        /// <param name="personalAccessToken">the token to use</param>
+        /// <remarks>FBN_LUSID_API_URL env variable will also need to be defined in order to use this approach</remarks>
+        public PersonalAccessTokenProvider(string personalAccessToken)
+        {
+            if (string.IsNullOrEmpty(personalAccessToken))
+            {
+                throw new ArgumentException("Expected a non empty personal access token");
+            }
+            _token = personalAccessToken;
+        }
+
+        /// <summary>
+        /// Gets the authentication token generated in LUSID web and stored as an env variable named FBN_ACCESS_TOKEN 
+        /// </summary>
+        /// <returns>the authentication token</returns>
+        public async Task<string> GetAuthenticationTokenAsync()
+        {
+            return await Task.FromResult(_token);
+        }
+
+        /// <summary>
+        /// Gets the authentication header.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderAsync()
+        {
+            string token = await this.GetAuthenticationTokenAsync();
+            return new AuthenticationHeaderValue("Bearer", token);
+        }
+    }
+} 

--- a/sdk/docker-compose.yml
+++ b/sdk/docker-compose.yml
@@ -14,5 +14,6 @@ services:
       - FBN_CLIENT_SECRET
       - FBN_LUSID_API_URL
       - FBN_APP_NAME
+      - FBN_ACCESS_TOKEN
     volumes:
       - .:/usr/src


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

* Updates NUnit and the NUnit Test Adapter; this provides better support for
  categorised tests among other niceties.
* Adds the token provider
* Give the PAT provider precedence over the ClientFlow Provider
* Adds tests
* Ensures tests that exclusively use the ClientFlow provider don't fail
  if those secrets can't be found.
* Ensures tests the exclusively use the PAT provider don't fail if those
  secrets can't be found.
* Tests that rely exclusively on one particular provider finish
  Inconclusive if the secrets do not exist.  Other tests are unaffected
  and will still require one or the other of the token providers to be
  valid.
* Enables testing with a PAT in github actions by making changes to the 
  Dockerfile and docker-compose files