### PR TITLE
CTECH-1344: Enables PR Flow integration tests to be run with a /LGTM comment on the PR

### DIFF
--- a/.github/workflows/build-and-test-branches.yaml
+++ b/.github/workflows/build-and-test-branches.yaml
@@ -1,0 +1,67 @@
+# This job runs the project tests
+
+name: Build and test main branches
+
+# Trigger the workflow on push or pull request to master or develop
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  # This workflow contains a single job called "build"
+  build-and-test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Set env variable BRANCH_FOR_SLACK for Slack message
+        run: |
+          if ${{ github.event_name == 'push' }} ; then
+            echo "BRANCH_FOR_SLACK=${{ github.ref  }}" >> $GITHUB_ENV
+          elif ${{ github.event_name == 'pull_request' }}; then
+            echo "BRANCH_FOR_SLACK=${{ github.base_ref  }}" >> $GITHUB_ENV
+          else
+            exit 1
+          fi
+
+      - name: Run tests
+        env:
+          FBN_TOKEN_URL: ${{ secrets.DEVELOP_FBN_TOKEN_URL }}
+          FBN_USERNAME: ${{ secrets.DEVELOP_FBN_USERNAME }}
+          FBN_PASSWORD: ${{ secrets.DEVELOP_FBN_PASSWORD }}
+          FBN_CLIENT_ID: ${{ secrets.DEVELOP_FBN_CLIENT_ID }}
+          FBN_CLIENT_SECRET: ${{ secrets.DEVELOP_FBN_CLIENT_SECRET }}
+          FBN_LUSID_API_URL: ${{ secrets.DEVELOP_FBN_LUSID_API_URL }}
+          FBN_APP_NAME: ${{ secrets.DEVELOP_FBN_CLIENT_ID }}
+          FBN_LUSID_ACCESS_TOKEN: ${{ secrets.DEVELOP_FBN_ACCESS_TOKEN }}
+        run: |
+          echo "env variables for DEVELOP have been set"
+          echo "Changing directory into sdk directory"
+          cd sdk          
+          echo "Running the tests..."
+          docker-compose up --abort-on-container-exit
+          echo "Tests COMPLETED"
+
+      - name: Slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,commit,repo,ref,author,took
+          custom_payload: |
+            {
+            username: 'github-actions-tests',
+            icon_emoji: ':octocat:',
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              text: `${process.env.AS_WORKFLOW} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.BRANCH_FOR_SLACK} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
+            }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure()

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,22 +5,63 @@ name: Build and test
 # Trigger the workflow on push or pull request to master or develop
 
 on:
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ master, develop ]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        type: string
+        required: true
+        description: The PR number.
 
 jobs:
   # This workflow contains a single job called "build"
   build-and-test:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
+    environment: "PR-${{ github.event.inputs.pull_request }}"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      # the tip of the merge request is required for the check_run progress
+      - name: Checkout for SHA
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.inputs.pull_request }}/head"
+
+      - name: Get SHA
+        id: vcs
+        run: echo "::set-output name=sha::$(git rev-parse HEAD)"
+
+      # but actually, we want to test what this is going to look like once it's been merged.
+      - name: Fork based /LGTM checkout
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.inputs.pull_request }}/merge"
+
+      # let the check run know it's in-progress; this shows up on the PR overview quite prominently
+      - name: Check Run in progress
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const date = new Date();
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: "${{ steps.vcs.outputs.sha }}",
+              name: "Integration Testing",
+
+              started_at: date.toISOString(),
+              external_id: "${{ github.run_id }}",
+              status: "in_progress",
+
+              output: {
+                title: "Integration Test Results",
+                summary: "Build started",
+                text: "Just gonna do stuff ya know."
+              }
+
+            });
 
       - name: Set env variable BRANCH_FOR_SLACK for Slack message
         run: |
@@ -32,43 +73,53 @@ jobs:
             exit 1
           fi
 
-      - name: Run tests on DEVELOP branch
-        if: ${{ github.base_ref == 'develop' || github.ref == 'refs/heads/develop' }}
-        env: 
-          FBN_TOKEN_URL: ${{ secrets.DEVELOP_FBN_TOKEN_URL }}
-          FBN_USERNAME: ${{ secrets.DEVELOP_FBN_USERNAME }}
-          FBN_PASSWORD: ${{ secrets.DEVELOP_FBN_PASSWORD }}
-          FBN_CLIENT_ID: ${{ secrets.DEVELOP_FBN_CLIENT_ID }}
-          FBN_CLIENT_SECRET: ${{ secrets.DEVELOP_FBN_CLIENT_SECRET }}
-          FBN_LUSID_API_URL: ${{ secrets.DEVELOP_FBN_LUSID_API_URL }}
-          FBN_APP_NAME: ${{ secrets.DEVELOP_FBN_CLIENT_ID }}
-          FBN_LUSID_ACCESS_TOKEN: ${{ secrets.DEVELOP_FBN_ACCESS_TOKEN }}
+      - name: Run tests
+        id: run_tests
+        env:
+          FBN_LUSID_API_URL: ${{ secrets.URI }}
+          FBN_ACCESS_TOKEN: ${{ secrets.TOKEN }}
         run: |
-          echo "env variables for DEVELOP have been set"
+          echo "env variables have been set"
           echo "Changing directory into sdk directory"
           cd sdk          
           echo "Running the tests..."
           docker-compose up --abort-on-container-exit
           echo "Tests COMPLETED"
-      
-      - name: Run tests on MASTER branch
-        if: ${{ github.base_ref == 'master' }}
-        env: 
-          FBN_TOKEN_URL: ${{ secrets.MASTER_FBN_TOKEN_URL }}
-          FBN_USERNAME: ${{ secrets.MASTER_FBN_USERNAME }}
-          FBN_PASSWORD: ${{ secrets.MASTER_FBN_PASSWORD }}
-          FBN_CLIENT_ID: ${{ secrets.MASTER_FBN_CLIENT_ID }}
-          FBN_CLIENT_SECRET: ${{ secrets.MASTER_FBN_CLIENT_SECRET }}
-          FBN_LUSID_API_URL: ${{ secrets.MASTER_FBN_LUSID_API_URL }}
-          FBN_APP_NAME: ${{ secrets.MASTER_FBN_CLIENT_ID }}
-          FBN_LUSID_ACCESS_TOKEN: ${{ secrets.MASTER_FBN_ACCESS_TOKEN }}
-        run: | 
-          echo "env variables for MASTER have been set"
-          echo "Changing directory into sdk directory"
-          cd sdk          
-          echo "Running the tests..."
-          docker-compose up --abort-on-container-exit
-          echo "Tests COMPLETED"
+
+      - name: Complete check run
+        if: always()
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const date = new Date();
+            const resp = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: "${{ github.run_id }}"
+            });
+
+            const URL = resp.data.jobs[0].html_url
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: "${{steps.vcs.outputs.sha}}",
+              name: "Integration Testing",
+
+              completed_at: date.toISOString(),
+
+              external_id: "${{ github.run_id }}",
+              details_url: resp.data.jobs[0].html_url,
+              status: "completed",
+              conclusion: "${{steps.run_tests.conclusion}}",
+
+              output: {
+                title: "Integration Tests",
+                summary: "Build completed with ${{steps.run_tests.conclusion}}",
+                text: `Visit the link to see the result of this step. ${URL}`
+              }
+            });
 
       - name: Slack notification
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
Signed-off-by: Paul Saunders <pms1969@gmail.com>

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

This PR enables untrusted contributors to supply a fork based PR to the project.  Once reviewed by a trusted contributor (TC); that is a contributor who is a member of the organisation; the TC can comment on the PR with `/LGTM`, triggering a test run against a synthetic domain.

The mechanics of the trigger are fairly simple; an organisation level webhook fires to a webhook service that then triggers the workflow_dispatch resulting in the `build-and-test.yaml` action to fire, which creates a check_run so that the results of the testing are displayed prominently for all to see.

* `build-and-test-branches.yaml` now effectively only runs tests on a merge to the `develop` branch.
* `build-and-test.yaml` runs only for `workflow_dispatch` which is the sequence of events outlined above.
* `CODEOWNERS` is there as a placeholder.  I want that to be used for any PR's that change any of the workflows; they are after all, quite sensitive.