### PR TITLE
ANA-1599: adjustment to strict inequality on cashflow windowing/override

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/StructuredResultStore.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/StructuredResultStore.cs
@@ -801,7 +801,7 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
         // Demonstrating querying using structured result store with overriden cashflows.
         [LusidFeature("F10-15")]
         [Test]
-        public void TestPortfolioUpsertableQueryWithOverridenCashFlows()
+        public void TestPortfolioCashflowQueryWithSrsOverridenCashFlows()
         {
             // Setting up basic parameters
             var effectiveAt = new DateTimeOffset(2019, 06, 28, 00, 00, 00, TimeSpan.Zero);
@@ -963,14 +963,14 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
            // Expecing a response.Values to contain a list of InstrumentCashflows, of which we expect the following property values.
            // | Amount | Currency | PaymentDate          |
            // | ------ | -------- | -------------------- |
-           // | 100000 | USD      | 28/6/2019 1:00:00 AM |
+           // | 100000 | USD      | 28/6/2019 1:00:00 AM |   <-- This cashflow will not appear as we have strict inequality in favour of the stored view. 
            // | 101000 | USD      | 05/7/2019 1:00:00 AM |
            // | 102000 | USD      | 12/7/2019 1:00:00 AM |
            // | 103000 | USD      | 19/7/2019 1:00:00 AM |
            var responseAmounts = response.Values.Select(x => x.Amount).ToList();
            var responseCurrencies = response.Values.Select(x => x.Currency).ToList();
-           Assert.That(responseAmounts, Is.EquivalentTo(new List<decimal> {100000, 101000, 102000, 103000}));
-           Assert.That(responseCurrencies, Is.EquivalentTo(new List<string> {"USD", "USD", "USD", "USD",}));
+           Assert.That(responseAmounts, Is.EquivalentTo(new List<decimal> {101000, 102000, 103000}));
+           Assert.That(responseCurrencies, Is.EquivalentTo(new List<string> {"USD", "USD", "USD",}));
         }
     }
 }

--- a/sdk/docker-compose.yml
+++ b/sdk/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - FBN_PASSWORD
       - FBN_CLIENT_ID
       - FBN_CLIENT_SECRET
-      - FBN_LUSID_API_URL
       - FBN_APP_NAME
+      - FBN_LUSID_API_URL=${FBN_BASE_API_URL}/api
       - FBN_ACCESS_TOKEN
     volumes:
       - .:/usr/src


### PR DESCRIPTION
- adjustment to cashflow windowing. The movements engine maintains the 'exact' current worldview. Overriding of cashflows should therefore be with strict inequality looking forward as opposed to 'greater than equals' inequality. 

- [ ] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
