### PR TITLE
CTECH-2254 Update the timeout to 2 minutes to deal with some prevalen…

### DIFF
--- a/sdk/Lusid.Sdk/Client/Configuration.cs
+++ b/sdk/Lusid.Sdk/Client/Configuration.cs
@@ -118,7 +118,7 @@ namespace Lusid.Sdk.Client
             };
 
             // Setting Timeout has side effects (forces ApiClient creation).
-            Timeout = 100000;
+            Timeout = 120000;
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Lusid.Sdk.Client
         public virtual IDictionary<string, string> DefaultHeaders { get; set; }
 
         /// <summary>
-        /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Default to 100000 milliseconds.
+        /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Default to 120000 milliseconds.
         /// </summary>
         public virtual int Timeout { get; set; }
 

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactory.cs
@@ -29,7 +29,7 @@ namespace Lusid.Sdk.Utilities
         /// <summary>
         /// Create a new factory using the specified configuration
         /// </summary>
-        public LusidApiFactory(ApiConfiguration apiConfiguration, int timeout = 100000)
+        public LusidApiFactory(ApiConfiguration apiConfiguration, int timeout = 120000)
         {
             if (apiConfiguration == null) throw new ArgumentNullException(nameof(apiConfiguration));
 

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactoryBuilder.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactoryBuilder.cs
@@ -10,7 +10,7 @@ namespace Lusid.Sdk.Utilities
         /// <summary>
         /// Create an ILusidApiFactory using the specified configuration file.  For details on the format of the configuration file see https://support.lusid.com/getting-started-with-apis-sdks
         /// </summary>
-        public static ILusidApiFactory Build(string apiSecretsFilename, int timeout = 100000)
+        public static ILusidApiFactory Build(string apiSecretsFilename, int timeout = 120000)
         {
             var apiConfig = ApiConfigurationBuilder.Build(apiSecretsFilename);
             return new LusidApiFactory(apiConfig, timeout);


### PR DESCRIPTION
…t timeouts under normal operating conditions

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

We are getting frequent client reports of timeouts against the calendars API under what we would consider to be very normal loads. Specifically, the timeouts are being generated from the C# SDK, not LUSID itself.

LUSID is responding with success codes roughly ten seconds after the SDK has timed out. So, in order to resolve this issue, we are raising the timeout threshold in the SDK from 100 seconds to 120 seconds.

The new timeout threshold should give us more consistent behaviour with LUSID and alleviate the issues observed by clients.